### PR TITLE
Add test that last definition wins in fileBackend

### DIFF
--- a/fixtures/flags_multiple_definitions.csv
+++ b/fixtures/flags_multiple_definitions.csv
@@ -1,0 +1,3 @@
+go.sun.money,.5
+go.moon.mercury,1
+go.sun.money,.7

--- a/flags.go
+++ b/flags.go
@@ -99,6 +99,8 @@ func parseFlagsCSV(r io.Reader) (map[string]Flag, error) {
 
 // BackendFromFile is a helper function that creates a valid
 // FlagBackend from a CSV file containing the feature flag values.
+// If the same flag is defined multiple times in the same file,
+// the last result will be used.
 func BackendFromFile(filename string) Backend {
 	return fileBackend{filename}
 }

--- a/flags_test.go
+++ b/flags_test.go
@@ -131,6 +131,18 @@ func TestRefresh(t *testing.T) {
 
 	assert.False(t, Enabled("go.sun.money"))
 	assert.True(t, Enabled("go.moon.mercury"))
+}
+
+func TestMultipleDefinitions(t *testing.T) {
+	const repeatedFlag = "go.sun.money"
+	const lastValue = 0.7
+	Reset()
+
+	backend := BackendFromFile(filepath.Join("fixtures", "flags_multiple_definitions.csv"))
+	RefreshFlags(backend)
+
+	flag := flags[repeatedFlag]
+	assert.Equal(t, flag, Flag{repeatedFlag, lastValue})
 
 }
 


### PR DESCRIPTION
If the same flag is defined multiple times in the file (when using the fileBackend), then the last write should win. This allows us to treat the file as append-only.



r? @stripe/observability 