### PR TITLE
goforit: Use a context instead of globals

### DIFF
--- a/examples_test.go
+++ b/examples_test.go
@@ -1,21 +1,28 @@
 package goforit
 
 import (
+	"context"
 	"fmt"
 	"time"
 )
 
 func Example() {
+	ctx := context.Background()
+
 	// flags.csv contains comma-separated flag names and sample rates.
 	// See: fixtures/flags_example.csv
 	backend := BackendFromFile("flags.csv")
 	Init(30*time.Second, backend)
 
-	if Enabled("go.sun.mercury") {
+	if Enabled(ctx, "go.sun.mercury") {
+		fmt.Println("The go.sun.mercury feature is enabled for 100% of requests")
+	}
+	// Same thing.
+	if Enabled(nil, "go.sun.mercury") {
 		fmt.Println("The go.sun.mercury feature is enabled for 100% of requests")
 	}
 
-	if Enabled("go.stars.money") {
+	if Enabled(ctx, "go.stars.money") {
 		fmt.Println("The go.stars.money feature is enabled for 50% of requests")
 	}
 }

--- a/examples_whitebox_test.go
+++ b/examples_whitebox_test.go
@@ -1,6 +1,7 @@
 package goforit_test
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -8,16 +9,22 @@ import (
 )
 
 func Example() {
+	ctx := context.Background()
+
 	// flags.csv contains comma-separated flag names and sample rates.
 	// See: fixtures/flags_example.csv
 	backend := goforit.BackendFromFile("flags.csv")
 	goforit.Init(30*time.Second, backend)
 
-	if goforit.Enabled("go.sun.mercury") {
+	if goforit.Enabled(ctx, "go.sun.mercury") {
+		fmt.Println("The go.sun.mercury feature is enabled for 100% of requests")
+	}
+	// Same thing.
+	if goforit.Enabled(nil, "go.sun.mercury") {
 		fmt.Println("The go.sun.mercury feature is enabled for 100% of requests")
 	}
 
-	if goforit.Enabled("go.stars.money") {
+	if goforit.Enabled(ctx, "go.stars.money") {
 		fmt.Println("The go.stars.money feature is enabled for 50% of requests")
 	}
 }


### PR DESCRIPTION
This should allow use of goforit even in code that will be under
test.