### PR TITLE
Don't allow clients to pass a RNG

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -24,8 +24,6 @@ func init() {
 
 const DefaultInterval = 30 * time.Second
 
-var Rand = rand.New(rand.NewSource(time.Now().Unix()))
-
 type Backend interface {
 	Refresh() (map[string]Flag, error)
 }
@@ -89,7 +87,7 @@ func Enabled(ctx context.Context, name string) (enabled bool) {
 
 	// equality should be strict
 	// because Float64() can return 0
-	if f := Rand.Float64(); f < flag.Rate {
+	if f := rand.Float64(); f < flag.Rate {
 		enabled = true
 		return
 	}

--- a/flags_test.go
+++ b/flags_test.go
@@ -2,7 +2,6 @@ package goforit
 
 import (
 	"context"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"sync"
@@ -18,7 +17,6 @@ const seed = 5194304667978865136
 const ε = .02
 
 func Reset() {
-	Rand = rand.New(rand.NewSource(seed))
 	flags = map[string]Flag{}
 	flagsMtx = sync.RWMutex{}
 }


### PR DESCRIPTION
The default RNG exposed by the math/rand package uses a locked source,
but in general RNGs generated by rand.Source are not safe for use by
multiple goroutines, and the default one exposed by goforit was no
exception.

Instead of exposing this foot-gun, and since nobody (not even the tests)
requires configuring this parameter, just remove it entirely.

r? @aditya-stripe 