### PR TITLE
Add v1 JSON File Backend Support

### DIFF
--- a/fixtures/flags_example.json
+++ b/fixtures/flags_example.json
@@ -1,10 +1,14 @@
-[
-  {
-    "Name" : "go.sun.mercury",
-    "Rate" : 1.0
-  },
-  {
-    "Name" : "go.stars.money",
-    "Rate" : 0.5
-  }
-]
+{
+  "flags" :
+    [
+      {
+        "Name" : "go.sun.mercury",
+        "Rate" : 1.0
+      },
+      {
+        "Name" : "go.stars.money",
+        "Rate" : 0.5
+      }
+    ],
+  "updated" : 1519164729.622348
+}

--- a/fixtures/flags_example.json
+++ b/fixtures/flags_example.json
@@ -1,0 +1,10 @@
+[
+  {
+    "Name" : "go.sun.mercury",
+    "Rate" : 1.0
+  },
+  {
+    "Name" : "go.stars.money",
+    "Rate" : 0.5
+  }
+]

--- a/fixtures/flags_example.json
+++ b/fixtures/flags_example.json
@@ -1,14 +1,9 @@
 {
-  "flags" :
-    [
-      {
-        "Name" : "go.sun.mercury",
-        "Rate" : 1.0
-      },
-      {
-        "Name" : "go.stars.money",
-        "Rate" : 0.5
-      }
-    ],
-  "updated" : 1519164729.622348
+  "flags": [
+    {
+      "Name": "sequins.prevent_download",
+      "Rate": 0
+    }
+  ],
+  "updated": 1519247256.0626957
 }

--- a/flags.go
+++ b/flags.go
@@ -33,10 +33,6 @@ type csvFileBackend struct {
 	filename string
 }
 
-type normalFileBackend struct {
-	filename string
-}
-
 type jsonFileBackend struct {
 	filename string
 }

--- a/flags.go
+++ b/flags.go
@@ -3,6 +3,7 @@ package goforit
 import (
 	"context"
 	"encoding/csv"
+	"encoding/json"
 	"fmt"
 	"io"
 	"math/rand"
@@ -10,7 +11,6 @@ import (
 	"strconv"
 	"sync"
 	"time"
-	"encoding/json"
 
 	"github.com/DataDog/datadog-go/statsd"
 )
@@ -40,7 +40,7 @@ type jsonFileBackend struct {
 func readFile(file string, backend string, parse func(io.Reader) (map[string]Flag, error)) (map[string]Flag, error) {
 	var checkStatus statsd.ServiceCheckStatus
 	defer func() {
-		stats.SimpleServiceCheck("goforit.refreshFlags." + backend + "FileBackend.present", checkStatus)
+		stats.SimpleServiceCheck("goforit.refreshFlags."+backend+"FileBackend.present", checkStatus)
 	}()
 	f, err := os.Open(file)
 	if err != nil {
@@ -65,7 +65,7 @@ type Flag struct {
 }
 
 type JSONFormat struct {
-  Flags []Flag `json:"flags"`
+	Flags []Flag `json:"flags"`
 }
 
 var flags = map[string]Flag{}

--- a/flags.go
+++ b/flags.go
@@ -64,6 +64,10 @@ type Flag struct {
 	Rate float64
 }
 
+type JSONFormat struct {
+  Flags []Flag `json:"flags"`
+}
+
 var flags = map[string]Flag{}
 var flagsMtx = sync.RWMutex{}
 
@@ -145,12 +149,12 @@ func parseFlagsCSV(r io.Reader) (map[string]Flag, error) {
 
 func parseFlagsJSON(r io.Reader) (map[string]Flag, error) {
 	dec := json.NewDecoder(r)
-	var v []Flag
+	var v JSONFormat
 	err := dec.Decode(&v)
 	if err != nil {
 		return nil, err
 	}
-	return flagsToMap(v), nil
+	return flagsToMap(v.Flags), nil
 }
 
 // BackendFromFile is a helper function that creates a valid

--- a/flags_test.go
+++ b/flags_test.go
@@ -64,6 +64,41 @@ func TestParseFlagsCSV(t *testing.T) {
 	}
 }
 
+func TestParseFlagsJSON(t *testing.T) {
+	filename := filepath.Join("fixtures", "flags_example.json")
+
+	type testcase struct {
+		Name     string
+		Filename string
+		Expected []Flag
+	}
+
+	cases := []testcase{
+		{
+			Name:     "BasicExample",
+			Filename: filepath.Join("fixtures", "flags_example.json"),
+			Expected: []Flag{
+				{
+					"sequins.prevent_download",
+					0,
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			f, err := os.Open(filename)
+			assert.NoError(t, err)
+			defer f.Close()
+
+			flags, err := parseFlagsJSON(f)
+
+			assertFlagsEqual(t, flagsToMap(tc.Expected), flags)
+		})
+	}
+}
+
 func TestEnabled(t *testing.T) {
 	const iterations = 100000
 


### PR DESCRIPTION
This PR is to add JSON file support (while keeping CSV around). We think this may be necessary for unlocking future functionality in goforit and also easier to interface with the database dump from Mongo. 

Note: I have not added test cases here, but have added a sample json file and spot test in a separate sample program.