### PR TITLE
Clean up goforit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ go:
   - 1.x
   - 1.7
   - 1.8
+  - 1.9
+  - '1.10'
   - tip
 
 script: go test -v -bench Bench ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7
+FROM golang:1.10
 MAINTAINER The Stripe Observability Team <support@stripe.com>
 
 RUN mkdir -p /build

--- a/backend.go
+++ b/backend.go
@@ -4,7 +4,6 @@ import (
 	"encoding/csv"
 	"encoding/json"
 	"io"
-	"log"
 	"os"
 	"strconv"
 	"time"

--- a/backend.go
+++ b/backend.go
@@ -1,0 +1,117 @@
+package goforit
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"io"
+	"log"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/DataDog/datadog-go/statsd"
+)
+
+type Backend interface {
+	// Refresh returns a new set of flags.
+	// It also returns the age of these flags, or an empty time if no age is known.
+	Refresh() (map[string]Flag, time.Time, error)
+}
+
+type csvFileBackend struct {
+	filename string
+}
+
+type jsonFileBackend struct {
+	filename string
+}
+
+type JSONFormat struct {
+	Flags       []Flag  `json:"flags"`
+	UpdatedTime float64 `json:"updated"`
+}
+
+func readFile(file string, backend string, parse func(io.Reader) (map[string]Flag, time.Time, error)) (map[string]Flag, time.Time, error) {
+	var checkStatus statsd.ServiceCheckStatus
+	defer func() {
+		stats.SimpleServiceCheck("goforit.refreshFlags."+backend+"FileBackend.present", checkStatus)
+	}()
+	f, err := os.Open(file)
+	if err != nil {
+		checkStatus = statsd.Warn
+		log.Print("[goforit] unable to open backend file:\n", err)
+		return nil, time.Time{}, err
+	}
+	defer f.Close()
+	return parse(f)
+}
+
+func (b jsonFileBackend) Refresh() (map[string]Flag, time.Time, error) {
+	return readFile(b.filename, "json", parseFlagsJSON)
+}
+
+func (b csvFileBackend) Refresh() (map[string]Flag, time.Time, error) {
+	return readFile(b.filename, "csv", parseFlagsCSV)
+}
+
+func flagsToMap(flags []Flag) map[string]Flag {
+	flagsMap := map[string]Flag{}
+	for _, flag := range flags {
+		flagsMap[flag.Name] = Flag{Name: flag.Name, Rate: flag.Rate}
+	}
+	return flagsMap
+}
+
+func parseFlagsCSV(r io.Reader) (map[string]Flag, time.Time, error) {
+	// every row is guaranteed to have 2 fields
+	const FieldsPerRecord = 2
+
+	cr := csv.NewReader(r)
+	cr.FieldsPerRecord = FieldsPerRecord
+	cr.TrimLeadingSpace = true
+
+	rows, err := cr.ReadAll()
+	if err != nil {
+		log.Print("[goforit] error parsing CSV file:\n", err)
+		return nil, time.Time{}, err
+	}
+
+	flags := map[string]Flag{}
+	for _, row := range rows {
+		name := row[0]
+
+		rate, err := strconv.ParseFloat(row[1], 64)
+		if err != nil {
+			// TODO also track somehow
+			rate = 0
+		}
+
+		flags[name] = Flag{Name: name, Rate: rate}
+	}
+	return flags, time.Time{}, nil
+}
+
+func parseFlagsJSON(r io.Reader) (map[string]Flag, time.Time, error) {
+	dec := json.NewDecoder(r)
+	var v JSONFormat
+	err := dec.Decode(&v)
+	if err != nil {
+		log.Print("[goforit] error parsing JSON file:\n", err)
+		return nil, time.Time{}, err
+	}
+	return flagsToMap(v.Flags), time.Unix(int64(v.UpdatedTime), 0), nil
+}
+
+// BackendFromFile is a helper function that creates a valid
+// FlagBackend from a CSV file containing the feature flag values.
+// If the same flag is defined multiple times in the same file,
+// the last result will be used.
+func BackendFromFile(filename string) Backend {
+	return csvFileBackend{filename}
+}
+
+// BackendFromJSONFile creates a backend powered by JSON file
+// instead of CSV
+func BackendFromJSONFile(filename string) Backend {
+	return jsonFileBackend{filename}
+}

--- a/backend.go
+++ b/backend.go
@@ -34,7 +34,7 @@ type JSONFormat struct {
 func readFile(file string, backend string, parse func(io.Reader) (map[string]Flag, time.Time, error)) (map[string]Flag, time.Time, error) {
 	var checkStatus statsd.ServiceCheckStatus
 	defer func() {
-		stats.SimpleServiceCheck("goforit.refreshFlags."+backend+"FileBackend.present", checkStatus)
+		globalGoforit.stats.SimpleServiceCheck("goforit.refreshFlags."+backend+"FileBackend.present", checkStatus)
 	}()
 	f, err := os.Open(file)
 	if err != nil {

--- a/backend_test.go
+++ b/backend_test.go
@@ -94,7 +94,7 @@ func TestMultipleDefinitions(t *testing.T) {
 	backend := BackendFromFile(filepath.Join("fixtures", "flags_multiple_definitions.csv"))
 	RefreshFlags(backend)
 
-	flag := flags[repeatedFlag]
+	flag := globalGoforit.flags[repeatedFlag]
 	assert.Equal(t, flag, Flag{repeatedFlag, lastValue})
 
 }

--- a/backend_test.go
+++ b/backend_test.go
@@ -95,9 +95,9 @@ func TestMultipleDefinitions(t *testing.T) {
 
 	const repeatedFlag = "go.sun.money"
 	const lastValue = 0.7
-	g, _ := testGoforit()
 
 	backend := BackendFromFile(filepath.Join("fixtures", "flags_multiple_definitions.csv"))
+	g, _ := testGoforit(0, backend)
 	g.RefreshFlags(backend)
 
 	flag := g.flags[repeatedFlag]

--- a/backend_test.go
+++ b/backend_test.go
@@ -1,0 +1,100 @@
+package goforit
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseFlagsCSV(t *testing.T) {
+	filename := filepath.Join("fixtures", "flags_example.csv")
+
+	type testcase struct {
+		Name     string
+		Filename string
+		Expected []Flag
+	}
+
+	cases := []testcase{
+		{
+			Name:     "BasicExample",
+			Filename: filepath.Join("fixtures", "flags_example.csv"),
+			Expected: []Flag{
+				{
+					"go.sun.money",
+					0,
+				},
+				{
+					"go.moon.mercury",
+					1,
+				},
+				{
+					"go.stars.money",
+					0.5,
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			f, err := os.Open(filename)
+			assert.NoError(t, err)
+			defer f.Close()
+
+			flags, _, err := parseFlagsCSV(f)
+
+			assertFlagsEqual(t, flagsToMap(tc.Expected), flags)
+		})
+	}
+}
+
+func TestParseFlagsJSON(t *testing.T) {
+	filename := filepath.Join("fixtures", "flags_example.json")
+
+	type testcase struct {
+		Name     string
+		Filename string
+		Expected []Flag
+	}
+
+	cases := []testcase{
+		{
+			Name:     "BasicExample",
+			Filename: filepath.Join("fixtures", "flags_example.json"),
+			Expected: []Flag{
+				{
+					"sequins.prevent_download",
+					0,
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			f, err := os.Open(filename)
+			assert.NoError(t, err)
+			defer f.Close()
+
+			flags, _, err := parseFlagsJSON(f)
+
+			assertFlagsEqual(t, flagsToMap(tc.Expected), flags)
+		})
+	}
+}
+
+func TestMultipleDefinitions(t *testing.T) {
+	const repeatedFlag = "go.sun.money"
+	const lastValue = 0.7
+	Reset()
+
+	backend := BackendFromFile(filepath.Join("fixtures", "flags_multiple_definitions.csv"))
+	RefreshFlags(backend)
+
+	flag := flags[repeatedFlag]
+	assert.Equal(t, flag, Flag{repeatedFlag, lastValue})
+
+}

--- a/backend_test.go
+++ b/backend_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestParseFlagsCSV(t *testing.T) {
+	t.Parallel()
+
 	filename := filepath.Join("fixtures", "flags_example.csv")
 
 	type testcase struct {
@@ -52,6 +54,8 @@ func TestParseFlagsCSV(t *testing.T) {
 }
 
 func TestParseFlagsJSON(t *testing.T) {
+	t.Parallel()
+
 	filename := filepath.Join("fixtures", "flags_example.json")
 
 	type testcase struct {
@@ -87,14 +91,16 @@ func TestParseFlagsJSON(t *testing.T) {
 }
 
 func TestMultipleDefinitions(t *testing.T) {
+	t.Parallel()
+
 	const repeatedFlag = "go.sun.money"
 	const lastValue = 0.7
-	Reset()
+	g, _ := testGoforit()
 
 	backend := BackendFromFile(filepath.Join("fixtures", "flags_multiple_definitions.csv"))
-	RefreshFlags(backend)
+	g.RefreshFlags(backend)
 
-	flag := globalGoforit.flags[repeatedFlag]
+	flag := g.flags[repeatedFlag]
 	assert.Equal(t, flag, Flag{repeatedFlag, lastValue})
 
 }

--- a/flags.go
+++ b/flags.go
@@ -45,6 +45,16 @@ type Flag struct {
 	Rate float64
 }
 
+// New creates a new goforit
+func New() *goforit {
+	stats, _ := statsd.New(statsdAddress)
+	return &goforit{
+		stats:              stats,
+		flags:              map[string]Flag{},
+		stalenessThreshold: defaultStalenessThreshold,
+	}
+}
+
 // Enabled returns a boolean indicating
 // whether or not the flag should be considered
 // enabled. It returns false if no flag with the specified

--- a/flags.go
+++ b/flags.go
@@ -33,6 +33,11 @@ var stats statsdClient
 var stalenessThreshold time.Duration = 5 * time.Minute
 var stalenessMtx = sync.RWMutex{}
 
+var flags = map[string]Flag{}
+var flagsMtx = sync.RWMutex{}
+var lastFlagRefreshTime time.Time
+var lastAssert time.Time
+
 func init() {
 	stats, _ = statsd.New(statsdAddress)
 }
@@ -85,12 +90,6 @@ type JSONFormat struct {
 	Flags       []Flag  `json:"flags"`
 	UpdatedTime float64 `json:"updated"`
 }
-
-var flags = map[string]Flag{}
-var flagsMtx = sync.RWMutex{}
-
-var lastFlagRefreshTime time.Time
-var lastAssert time.Time
 
 // Enabled returns a boolean indicating
 // whether or not the flag should be considered

--- a/flags.go
+++ b/flags.go
@@ -2,14 +2,9 @@ package goforit
 
 import (
 	"context"
-	"encoding/csv"
-	"encoding/json"
 	"fmt"
-	"io"
 	"log"
 	"math/rand"
-	"os"
-	"strconv"
 	"sync"
 	"time"
 
@@ -44,51 +39,9 @@ func init() {
 
 const DefaultInterval = 30 * time.Second
 
-type Backend interface {
-	// Refresh returns a new set of flags.
-	// It also returns the age of these flags, or an empty time if no age is known.
-	Refresh() (map[string]Flag, time.Time, error)
-}
-
-type csvFileBackend struct {
-	filename string
-}
-
-type jsonFileBackend struct {
-	filename string
-}
-
-func readFile(file string, backend string, parse func(io.Reader) (map[string]Flag, time.Time, error)) (map[string]Flag, time.Time, error) {
-	var checkStatus statsd.ServiceCheckStatus
-	defer func() {
-		stats.SimpleServiceCheck("goforit.refreshFlags."+backend+"FileBackend.present", checkStatus)
-	}()
-	f, err := os.Open(file)
-	if err != nil {
-		checkStatus = statsd.Warn
-		log.Print("[goforit] unable to open backend file:\n", err)
-		return nil, time.Time{}, err
-	}
-	defer f.Close()
-	return parse(f)
-}
-
-func (b jsonFileBackend) Refresh() (map[string]Flag, time.Time, error) {
-	return readFile(b.filename, "json", parseFlagsJSON)
-}
-
-func (b csvFileBackend) Refresh() (map[string]Flag, time.Time, error) {
-	return readFile(b.filename, "csv", parseFlagsCSV)
-}
-
 type Flag struct {
 	Name string
 	Rate float64
-}
-
-type JSONFormat struct {
-	Flags       []Flag  `json:"flags"`
-	UpdatedTime float64 `json:"updated"`
 }
 
 // Enabled returns a boolean indicating
@@ -140,68 +93,6 @@ func Enabled(ctx context.Context, name string) (enabled bool) {
 	}
 	enabled = false
 	return
-}
-
-func flagsToMap(flags []Flag) map[string]Flag {
-	flagsMap := map[string]Flag{}
-	for _, flag := range flags {
-		flagsMap[flag.Name] = Flag{Name: flag.Name, Rate: flag.Rate}
-	}
-	return flagsMap
-}
-
-func parseFlagsCSV(r io.Reader) (map[string]Flag, time.Time, error) {
-	// every row is guaranteed to have 2 fields
-	const FieldsPerRecord = 2
-
-	cr := csv.NewReader(r)
-	cr.FieldsPerRecord = FieldsPerRecord
-	cr.TrimLeadingSpace = true
-
-	rows, err := cr.ReadAll()
-	if err != nil {
-		log.Print("[goforit] error parsing CSV file:\n", err)
-		return nil, time.Time{}, err
-	}
-
-	flags := map[string]Flag{}
-	for _, row := range rows {
-		name := row[0]
-
-		rate, err := strconv.ParseFloat(row[1], 64)
-		if err != nil {
-			// TODO also track somehow
-			rate = 0
-		}
-
-		flags[name] = Flag{Name: name, Rate: rate}
-	}
-	return flags, time.Time{}, nil
-}
-
-func parseFlagsJSON(r io.Reader) (map[string]Flag, time.Time, error) {
-	dec := json.NewDecoder(r)
-	var v JSONFormat
-	err := dec.Decode(&v)
-	if err != nil {
-		log.Print("[goforit] error parsing JSON file:\n", err)
-		return nil, time.Time{}, err
-	}
-	return flagsToMap(v.Flags), time.Unix(int64(v.UpdatedTime), 0), nil
-}
-
-// BackendFromFile is a helper function that creates a valid
-// FlagBackend from a CSV file containing the feature flag values.
-// If the same flag is defined multiple times in the same file,
-// the last result will be used.
-func BackendFromFile(filename string) Backend {
-	return csvFileBackend{filename}
-}
-
-// BackendFromJSONFile creates a backend powered by JSON file
-// instead of CSV
-func BackendFromJSONFile(filename string) Backend {
-	return jsonFileBackend{filename}
 }
 
 // RefreshFlags will use the provided thunk function to

--- a/flags.go
+++ b/flags.go
@@ -202,11 +202,11 @@ func (g *goforit) SetStalenessThreshold(threshold time.Duration) {
 func (g *goforit) Init(interval time.Duration, backend Backend) *time.Ticker {
 
 	ticker := time.NewTicker(interval)
-	RefreshFlags(backend)
+	g.RefreshFlags(backend)
 
 	go func() {
 		for _ = range ticker.C {
-			RefreshFlags(backend)
+			g.RefreshFlags(backend)
 		}
 	}()
 	return ticker

--- a/flags_test.go
+++ b/flags_test.go
@@ -24,84 +24,6 @@ func Reset() {
 	stats, _ = statsd.New(statsdAddress)
 }
 
-func TestParseFlagsCSV(t *testing.T) {
-	filename := filepath.Join("fixtures", "flags_example.csv")
-
-	type testcase struct {
-		Name     string
-		Filename string
-		Expected []Flag
-	}
-
-	cases := []testcase{
-		{
-			Name:     "BasicExample",
-			Filename: filepath.Join("fixtures", "flags_example.csv"),
-			Expected: []Flag{
-				{
-					"go.sun.money",
-					0,
-				},
-				{
-					"go.moon.mercury",
-					1,
-				},
-				{
-					"go.stars.money",
-					0.5,
-				},
-			},
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.Name, func(t *testing.T) {
-			f, err := os.Open(filename)
-			assert.NoError(t, err)
-			defer f.Close()
-
-			flags, _, err := parseFlagsCSV(f)
-
-			assertFlagsEqual(t, flagsToMap(tc.Expected), flags)
-		})
-	}
-}
-
-func TestParseFlagsJSON(t *testing.T) {
-	filename := filepath.Join("fixtures", "flags_example.json")
-
-	type testcase struct {
-		Name     string
-		Filename string
-		Expected []Flag
-	}
-
-	cases := []testcase{
-		{
-			Name:     "BasicExample",
-			Filename: filepath.Join("fixtures", "flags_example.json"),
-			Expected: []Flag{
-				{
-					"sequins.prevent_download",
-					0,
-				},
-			},
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.Name, func(t *testing.T) {
-			f, err := os.Open(filename)
-			assert.NoError(t, err)
-			defer f.Close()
-
-			flags, _, err := parseFlagsJSON(f)
-
-			assertFlagsEqual(t, flagsToMap(tc.Expected), flags)
-		})
-	}
-}
-
 func TestEnabled(t *testing.T) {
 	const iterations = 100000
 
@@ -172,19 +94,6 @@ func TestRefresh(t *testing.T) {
 
 	assert.False(t, Enabled(context.Background(), "go.sun.money"))
 	assert.True(t, Enabled(context.Background(), "go.moon.mercury"))
-}
-
-func TestMultipleDefinitions(t *testing.T) {
-	const repeatedFlag = "go.sun.money"
-	const lastValue = 0.7
-	Reset()
-
-	backend := BackendFromFile(filepath.Join("fixtures", "flags_multiple_definitions.csv"))
-	RefreshFlags(backend)
-
-	flag := flags[repeatedFlag]
-	assert.Equal(t, flag, Flag{repeatedFlag, lastValue})
-
 }
 
 // BenchmarkEnabled runs a benchmark for a feature flag

--- a/flags_test.go
+++ b/flags_test.go
@@ -58,7 +58,7 @@ type dummyBackend struct {
 	refreshedCount int
 }
 
-func (b *dummyBackend) Refresh(*goforit) (map[string]Flag, time.Time, error) {
+func (b *dummyBackend) Refresh() (map[string]Flag, time.Time, error) {
 	defer func() {
 		b.refreshedCount++
 	}()
@@ -234,7 +234,7 @@ type dummyAgeBackend struct {
 	mtx sync.RWMutex
 }
 
-func (b *dummyAgeBackend) Refresh(*goforit) (map[string]Flag, time.Time, error) {
+func (b *dummyAgeBackend) Refresh() (map[string]Flag, time.Time, error) {
 	b.mtx.RLock()
 	defer b.mtx.RUnlock()
 	return map[string]Flag{}, b.t, nil

--- a/flags_test.go
+++ b/flags_test.go
@@ -2,8 +2,6 @@ package goforit
 
 import (
 	"context"
-	"encoding/json"
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -13,7 +11,6 @@ import (
 
 	"github.com/DataDog/datadog-go/statsd"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // arbitrary but fixed for reproducible testing
@@ -310,25 +307,6 @@ func (m *mockHistogramClient) Histogram(name string, value float64, tags []strin
 		m.histogramValues = append(m.histogramValues, value)
 	}
 	return nil
-}
-
-func writeMockJSONFile(t *testing.T, path string, updatedPeriod time.Duration) {
-	flags := []Flag{{"go.sun.money", 1.0}}
-	updatedTime := time.Now().Add(updatedPeriod)
-	flagsJson := &JSONFormat{flags, float64(updatedTime.Unix())}
-
-	jsonData, err := json.Marshal(flagsJson)
-	require.NoError(t, err)
-
-	tmp, err := ioutil.TempFile(filepath.Dir(path), "flags-temp-")
-	require.NoError(t, err)
-	defer os.Remove(tmp.Name())
-	_, err = tmp.Write(jsonData)
-	require.NoError(t, err)
-	tmp.Close()
-
-	err = os.Rename(tmp.Name(), path)
-	require.NoError(t, err)
 }
 
 type dummyAgeBackend struct {

--- a/flags_test.go
+++ b/flags_test.go
@@ -21,7 +21,7 @@ const ε = .02
 
 func Reset() {
 	rand.Seed(seed)
-	initGlobal()
+	globalGoforit = New()
 }
 
 func TestEnabled(t *testing.T) {

--- a/flags_test.go
+++ b/flags_test.go
@@ -20,8 +20,8 @@ const seed = 5194304667978865136
 const ε = .02
 
 func Reset() {
-	rand.Seed(seed)
 	globalGoforit = New()
+	globalGoforit.rnd = rand.New(rand.NewSource(seed))
 }
 
 func TestEnabled(t *testing.T) {

--- a/flags_test.go
+++ b/flags_test.go
@@ -58,7 +58,7 @@ type dummyBackend struct {
 	refreshedCount int
 }
 
-func (b *dummyBackend) Refresh() (map[string]Flag, time.Time, error) {
+func (b *dummyBackend) Refresh(*goforit) (map[string]Flag, time.Time, error) {
 	defer func() {
 		b.refreshedCount++
 	}()
@@ -234,7 +234,7 @@ type dummyAgeBackend struct {
 	mtx sync.RWMutex
 }
 
-func (b *dummyAgeBackend) Refresh() (map[string]Flag, time.Time, error) {
+func (b *dummyAgeBackend) Refresh(*goforit) (map[string]Flag, time.Time, error) {
 	b.mtx.RLock()
 	defer b.mtx.RUnlock()
 	return map[string]Flag{}, b.t, nil

--- a/flags_test.go
+++ b/flags_test.go
@@ -21,9 +21,7 @@ const ε = .02
 
 func Reset() {
 	rand.Seed(seed)
-	flags = map[string]Flag{}
-	flagsMtx = sync.RWMutex{}
-	stats, _ = statsd.New(statsdAddress)
+	initGlobal()
 }
 
 func TestEnabled(t *testing.T) {
@@ -234,8 +232,8 @@ func (b *dummyAgeBackend) Refresh() (map[string]Flag, time.Time, error) {
 // Test to see proper monitoring of age of the flags dump
 func TestCacheFileMetric(t *testing.T) {
 	Reset()
-	mockStats := &mockHistogramClient{stats.(*statsd.Client), "goforit.flags.cache_file_age_s", []float64{}, sync.RWMutex{}}
-	stats = mockStats
+	mockStats := &mockHistogramClient{globalGoforit.stats.(*statsd.Client), "goforit.flags.cache_file_age_s", []float64{}, sync.RWMutex{}}
+	globalGoforit.stats = mockStats
 
 	backend := &dummyAgeBackend{t: time.Now().Add(-10 * time.Minute)}
 	ticker := Init(10*time.Millisecond, backend)
@@ -282,8 +280,8 @@ func TestCacheFileMetric(t *testing.T) {
 // Test to see proper monitoring of refreshing the flags dump file from disc
 func TestRefreshCycleMetric(t *testing.T) {
 	Reset()
-	mockStats := &mockHistogramClient{stats.(*statsd.Client), "goforit.flags.last_refresh_s", []float64{}, sync.RWMutex{}}
-	stats = mockStats
+	mockStats := &mockHistogramClient{globalGoforit.stats.(*statsd.Client), "goforit.flags.last_refresh_s", []float64{}, sync.RWMutex{}}
+	globalGoforit.stats = mockStats
 	ctx := context.Background()
 
 	backend := &dummyBackend{}

--- a/flags_test.go
+++ b/flags_test.go
@@ -3,6 +3,7 @@ package goforit
 import (
 	"context"
 	"math"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"sync"
@@ -19,6 +20,7 @@ const seed = 5194304667978865136
 const ε = .02
 
 func Reset() {
+	rand.Seed(seed)
 	flags = map[string]Flag{}
 	flagsMtx = sync.RWMutex{}
 	stats, _ = statsd.New(statsdAddress)

--- a/global.go
+++ b/global.go
@@ -1,0 +1,35 @@
+package goforit
+
+import (
+	"context"
+	"time"
+
+	"github.com/DataDog/datadog-go/statsd"
+)
+
+var globalGoforit goforit
+
+func initGlobal() {
+	globalGoforit.stats, _ = statsd.New(statsdAddress)
+	globalGoforit.flags = map[string]Flag{}
+}
+
+func init() {
+	initGlobal()
+}
+
+func Enabled(ctx context.Context, name string) (enabled bool) {
+	return globalGoforit.Enabled(ctx, name)
+}
+
+func RefreshFlags(backend Backend) error {
+	return globalGoforit.RefreshFlags(backend)
+}
+
+func SetStalenessThreshold(threshold time.Duration) {
+	globalGoforit.SetStalenessThreshold(threshold)
+}
+
+func Init(interval time.Duration, backend Backend) *time.Ticker {
+	return globalGoforit.Init(interval, backend)
+}

--- a/global.go
+++ b/global.go
@@ -3,19 +3,12 @@ package goforit
 import (
 	"context"
 	"time"
-
-	"github.com/DataDog/datadog-go/statsd"
 )
 
-var globalGoforit goforit
-
-func initGlobal() {
-	globalGoforit.stats, _ = statsd.New(statsdAddress)
-	globalGoforit.flags = map[string]Flag{}
-}
+var globalGoforit *goforit
 
 func init() {
-	initGlobal()
+	globalGoforit = New()
 }
 
 func Enabled(ctx context.Context, name string) (enabled bool) {

--- a/global.go
+++ b/global.go
@@ -15,8 +15,8 @@ func Enabled(ctx context.Context, name string) (enabled bool) {
 	return globalGoforit.Enabled(ctx, name)
 }
 
-func RefreshFlags(backend Backend) error {
-	return globalGoforit.RefreshFlags(backend)
+func RefreshFlags(backend Backend) {
+	globalGoforit.RefreshFlags(backend)
 }
 
 func SetStalenessThreshold(threshold time.Duration) {

--- a/global.go
+++ b/global.go
@@ -8,7 +8,7 @@ import (
 var globalGoforit *goforit
 
 func init() {
-	globalGoforit = New()
+	globalGoforit = newWithoutInit()
 }
 
 func Enabled(ctx context.Context, name string) (enabled bool) {
@@ -23,6 +23,10 @@ func SetStalenessThreshold(threshold time.Duration) {
 	globalGoforit.SetStalenessThreshold(threshold)
 }
 
-func Init(interval time.Duration, backend Backend) *time.Ticker {
-	return globalGoforit.Init(interval, backend)
+func Init(interval time.Duration, backend Backend) {
+	globalGoforit.init(interval, backend)
+}
+
+func Close() error {
+	return globalGoforit.Close()
 }


### PR DESCRIPTION
Step-by-step cleanup. Each step should be more or less self-evident!

* Remove almost all globals
* Allow tests to run in parallel (and in general, allow multiple goforit processes)
* Allow testing log output, and use that to test staleness
* Remove a bunch of cruft
