### PR TITLE
Complex FF Definition

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -1,9 +1,9 @@
 package goforit
 
 import (
-	"errors"
 	"encoding/csv"
 	"encoding/json"
+	"errors"
 	"io"
 	"os"
 	"strconv"
@@ -27,19 +27,19 @@ type jsonFileBackend struct {
 type flagJson struct {
 	Name   string
 	Active bool
-	Rate  float64
+	Rate   float64
 	Rules  []RuleInfo
 }
 
 type ruleInfoJson struct {
-	Type string `json:"type"`
-	OnMatch  RuleAction `json:"on_match"`
-	OnMiss   RuleAction `json:"on_miss"`
+	Type    string     `json:"type"`
+	OnMatch RuleAction `json:"on_match"`
+	OnMiss  RuleAction `json:"on_miss"`
 }
 
 type JSONFormat struct {
-	Flags       []Flag `json:"flags"`
-	UpdatedTime float64          `json:"updated"`
+	Flags       []Flag  `json:"flags"`
+	UpdatedTime float64 `json:"updated"`
 }
 
 func (ri *Flag) UnmarshalJSON(buf []byte) error {
@@ -50,7 +50,7 @@ func (ri *Flag) UnmarshalJSON(buf []byte) error {
 	}
 
 	if len(raw.Rules) == 0 {
-		if(raw.Rate > 0) {
+		if raw.Rate > 0 {
 			raw.Active = true
 			raw.Rules = []RuleInfo{
 				{&RateRule{Rate: raw.Rate}, RuleOn, RuleOff},
@@ -59,7 +59,7 @@ func (ri *Flag) UnmarshalJSON(buf []byte) error {
 	}
 
 	ri.Name = raw.Name
- 	ri.Active = raw.Active
+	ri.Active = raw.Active
 	ri.Rules = raw.Rules
 
 	return nil
@@ -90,7 +90,7 @@ func (ri *RuleInfo) UnmarshalJSON(buf []byte) error {
 		ri.Rule = &RateRule{}
 	default:
 		return errors.New("Bad type") // TODO: custom error type
- 	}
+	}
 
 	return json.Unmarshal(buf, ri.Rule)
 }

--- a/backend.go
+++ b/backend.go
@@ -42,14 +42,19 @@ type JSONFormat struct {
 	UpdatedTime float64 `json:"updated"`
 }
 
+// While the goforit client allows for complex feature flag functionality, it is possible to have
+//simple flags that specify only Name and Rate (at least for the time being).Instead of using
+// versions to formalize this, we will write some simple logic in a custom Unmarshaler to handle
+// both cases
 func (ri *Flag) UnmarshalJSON(buf []byte) error {
 	var raw flagJson
 	err := json.Unmarshal(buf, &raw)
 	if err != nil {
 		return err
 	}
-
 	if len(raw.Rules) == 0 {
+		// if no rules are specified, we create a RateRule if a non-zero rate was specified, and ensure
+		// the flag is active. if no rate was specified, active should be default to false
 		if raw.Rate > 0 {
 			raw.Active = true
 			raw.Rules = []RuleInfo{

--- a/backend.go
+++ b/backend.go
@@ -24,6 +24,13 @@ type jsonFileBackend struct {
 	filename string
 }
 
+type flagJson struct {
+	Name   string
+	Active bool
+	Rate  float64
+	Rules  []RuleInfo
+}
+
 type ruleInfoJson struct {
 	Type string `json:"type"`
 	OnMatch  RuleAction `json:"on_match"`
@@ -33,6 +40,29 @@ type ruleInfoJson struct {
 type JSONFormat struct {
 	Flags       []Flag `json:"flags"`
 	UpdatedTime float64          `json:"updated"`
+}
+
+func (ri *Flag) UnmarshalJSON(buf []byte) error {
+	var raw flagJson
+	err := json.Unmarshal(buf, &raw)
+	if err != nil {
+		return err
+	}
+
+	if len(raw.Rules) == 0 {
+		if(raw.Rate > 0) {
+			raw.Active = true
+			raw.Rules = []RuleInfo{
+				{&RateRule{Rate: raw.Rate}, RuleOn, RuleOff},
+			}
+		}
+	}
+
+	ri.Name = raw.Name
+ 	ri.Active = raw.Active
+	ri.Rules = raw.Rules
+
+	return nil
 }
 
 func (ri *RuleInfo) UnmarshalJSON(buf []byte) error {

--- a/backend_test.go
+++ b/backend_test.go
@@ -81,6 +81,13 @@ func TestParseFlagsJSON(t *testing.T) {
 						{&RateRule{0.01, []string{"cluster", "db"}}, RuleOn, RuleOff},
 					},
 				},
+				{
+					"go.sun.mercury",
+					true,
+					[]RuleInfo{
+						{&RateRule{Rate: 0.5}, RuleOn, RuleOff},
+					},
+				},
 			},
 		},
 	}

--- a/backend_test.go
+++ b/backend_test.go
@@ -109,6 +109,6 @@ func TestMultipleDefinitions(t *testing.T) {
 	g.RefreshFlags(backend)
 
 	flag := g.flags[repeatedFlag]
-	assert.Equal(t, flag, Flag{repeatedFlag, true, []RuleInfo{{&RateRule{Rate:lastValue}, RuleOn, RuleOff}}})
+	assert.Equal(t, flag, Flag{repeatedFlag, true, []RuleInfo{{&RateRule{Rate: lastValue}, RuleOn, RuleOff}}})
 
 }

--- a/examples_test.go
+++ b/examples_test.go
@@ -14,7 +14,7 @@ func Example() {
 	backend := BackendFromFile("flags.csv")
 	Init(30*time.Second, backend)
 
-	if Enabled(ctx, "go.sun.mercury",  map[string]string{"host_name": "apibox_789"}) {
+	if Enabled(ctx, "go.sun.mercury", map[string]string{"host_name": "apibox_789"}) {
 		fmt.Println("The go.sun.mercury feature is enabled for 100% of requests")
 	}
 	// Same thing.

--- a/examples_test.go
+++ b/examples_test.go
@@ -14,18 +14,15 @@ func Example() {
 	backend := BackendFromFile("flags.csv")
 	Init(30*time.Second, backend)
 
-	enabled, err := Enabled(ctx, "go.sun.moon", map[string]string{"host_name": "apibox_123"})
-	if err == nil && enabled {
+	if Enabled(ctx, "go.sun.mercury") {
 		fmt.Println("The go.sun.mercury feature is enabled for 100% of requests")
 	}
 	// Same thing.
-	enabled, err = Enabled(nil, "go.sun.mercury", nil)
-	if err == nil && enabled {
+	if Enabled(nil, "go.sun.mercury") {
 		fmt.Println("The go.sun.mercury feature is enabled for 100% of requests")
 	}
 
-	enabled, err = Enabled(ctx, "go.stars.money", nil)
-	if err == nil && enabled {
+	if Enabled(ctx, "go.stars.money") {
 		fmt.Println("The go.stars.money feature is enabled for 50% of requests")
 	}
 }

--- a/examples_test.go
+++ b/examples_test.go
@@ -14,15 +14,18 @@ func Example() {
 	backend := BackendFromFile("flags.csv")
 	Init(30*time.Second, backend)
 
-	if Enabled(ctx, "go.sun.mercury") {
+	enabled, err := Enabled(ctx, "go.sun.moon", map[string]string{"host_name": "apibox_123"})
+	if err == nil && enabled {
 		fmt.Println("The go.sun.mercury feature is enabled for 100% of requests")
 	}
 	// Same thing.
-	if Enabled(nil, "go.sun.mercury") {
+	enabled, err = Enabled(nil, "go.sun.mercury",nil)
+	if err == nil && enabled {
 		fmt.Println("The go.sun.mercury feature is enabled for 100% of requests")
 	}
 
-	if Enabled(ctx, "go.stars.money") {
+	enabled, err = Enabled(ctx, "go.stars.money",nil)
+	if err == nil && enabled {
 		fmt.Println("The go.stars.money feature is enabled for 50% of requests")
 	}
 }

--- a/examples_test.go
+++ b/examples_test.go
@@ -19,12 +19,12 @@ func Example() {
 		fmt.Println("The go.sun.mercury feature is enabled for 100% of requests")
 	}
 	// Same thing.
-	enabled, err = Enabled(nil, "go.sun.mercury",nil)
+	enabled, err = Enabled(nil, "go.sun.mercury", nil)
 	if err == nil && enabled {
 		fmt.Println("The go.sun.mercury feature is enabled for 100% of requests")
 	}
 
-	enabled, err = Enabled(ctx, "go.stars.money",nil)
+	enabled, err = Enabled(ctx, "go.stars.money", nil)
 	if err == nil && enabled {
 		fmt.Println("The go.stars.money feature is enabled for 50% of requests")
 	}

--- a/examples_whitebox_test.go
+++ b/examples_whitebox_test.go
@@ -21,12 +21,12 @@ func Example() {
 		fmt.Println("The go.sun.mercury feature is enabled for 100% of requests")
 	}
 	// Same thing.
-	enabled, err = goforit.Enabled(nil, "go.sun.mercury",nil)
+	enabled, err = goforit.Enabled(nil, "go.sun.mercury", nil)
 	if err == nil && enabled {
 		fmt.Println("The go.sun.mercury feature is enabled for 100% of requests")
 	}
 
-	enabled, err = goforit.Enabled(ctx, "go.stars.money",nil)
+	enabled, err = goforit.Enabled(ctx, "go.stars.money", nil)
 	if err == nil && enabled {
 		fmt.Println("The go.stars.money feature is enabled for 50% of requests")
 	}

--- a/examples_whitebox_test.go
+++ b/examples_whitebox_test.go
@@ -16,18 +16,15 @@ func Example() {
 	backend := goforit.BackendFromFile("flags.csv")
 	goforit.Init(30*time.Second, backend)
 
-	enabled, err := goforit.Enabled(ctx, "go.sun.moon", map[string]string{"host_name": "apibox_123"})
-	if err == nil && enabled {
+	if goforit.Enabled(ctx, "go.sun.mercury") {
 		fmt.Println("The go.sun.mercury feature is enabled for 100% of requests")
 	}
 	// Same thing.
-	enabled, err = goforit.Enabled(nil, "go.sun.mercury", nil)
-	if err == nil && enabled {
+	if goforit.Enabled(nil, "go.sun.mercury") {
 		fmt.Println("The go.sun.mercury feature is enabled for 100% of requests")
 	}
 
-	enabled, err = goforit.Enabled(ctx, "go.stars.money", nil)
-	if err == nil && enabled {
+	if goforit.Enabled(ctx, "go.stars.money") {
 		fmt.Println("The go.stars.money feature is enabled for 50% of requests")
 	}
 }

--- a/examples_whitebox_test.go
+++ b/examples_whitebox_test.go
@@ -16,15 +16,18 @@ func Example() {
 	backend := goforit.BackendFromFile("flags.csv")
 	goforit.Init(30*time.Second, backend)
 
-	if goforit.Enabled(ctx, "go.sun.mercury") {
+	enabled, err := goforit.Enabled(ctx, "go.sun.moon", map[string]string{"host_name": "apibox_123"})
+	if err == nil && enabled {
 		fmt.Println("The go.sun.mercury feature is enabled for 100% of requests")
 	}
 	// Same thing.
-	if goforit.Enabled(nil, "go.sun.mercury") {
+	enabled, err = goforit.Enabled(nil, "go.sun.mercury",nil)
+	if err == nil && enabled {
 		fmt.Println("The go.sun.mercury feature is enabled for 100% of requests")
 	}
 
-	if goforit.Enabled(ctx, "go.stars.money") {
+	enabled, err = goforit.Enabled(ctx, "go.stars.money",nil)
+	if err == nil && enabled {
 		fmt.Println("The go.stars.money feature is enabled for 50% of requests")
 	}
 }

--- a/fixtures/flags_example.json
+++ b/fixtures/flags_example.json
@@ -31,6 +31,10 @@
           "on_miss": "off"
         }
       ]
+    },
+    {
+      "name": "go.sun.mercury",
+      "rate": 0.5
     }
   ],
   "updated": 1519247256.0626957

--- a/fixtures/flags_example.json
+++ b/fixtures/flags_example.json
@@ -1,8 +1,36 @@
 {
   "flags": [
     {
-      "Name": "sequins.prevent_download",
-      "Rate": 0
+      "name": "go.sun.moon",
+      "active": true,
+      "rules": [
+        {
+          "type": "match_list",
+          "property": "host_name",
+          "values": [
+            "apibox_123",
+            "apibox_456"
+          ],
+          "on_match": "off",
+          "on_miss": "continue"
+        },
+        {
+          "type": "match_list",
+          "property": "host_name",
+          "values": [
+            "apibox_789"
+          ],
+          "on_match": "on",
+          "on_miss": "continue"
+        },
+        {
+          "type": "sample",
+          "rate": 0.01,
+          "properties": ["cluster", "db"],
+          "on_match": "on",
+          "on_miss": "off"
+        }
+      ]
     }
   ],
   "updated": 1519247256.0626957

--- a/flags.go
+++ b/flags.go
@@ -107,7 +107,7 @@ type RuleInfo struct {
 }
 
 type Rule interface {
-	Handle(props map[string]string) (bool, error)
+	Handle(flag string, props map[string]string) (bool, error)
 }
 
 type MatchListRule struct {
@@ -208,7 +208,7 @@ func (g *goforit) Enabled(ctx context.Context, name string, properties map[strin
 	}
 
 	for _, r := range flag.Rules {
-		res, err := r.Rule.Handle(mergedProperties)
+		res, err := r.Rule.Handle(flag.Name, mergedProperties)
 		if err != nil {
 			log.Printf("[goforit] error evaluating rule:\n", err)
 			return
@@ -251,13 +251,14 @@ func getProperty(props map[string]string, prop string) (string, error) {
 	}
 }
 
-func (r *RateRule) Handle(props map[string]string) (bool, error) {
+func (r *RateRule) Handle(flag string, props map[string]string) (bool, error) {
 	if r.Properties != nil {
 		// get the sha1 of the properties values concat
 		h := sha1.New()
 		// sort the properties for consistent behavior (should we sort on Refresh()?)
 		sort.Strings(r.Properties)
 		var buffer bytes.Buffer
+		buffer.WriteString(flag)
 		for _, val := range r.Properties {
 			prop, err := getProperty(props, val)
 			if err != nil {
@@ -278,7 +279,7 @@ func (r *RateRule) Handle(props map[string]string) (bool, error) {
 	}
 }
 
-func (r *MatchListRule) Handle(props map[string]string) (bool, error) {
+func (r *MatchListRule) Handle(flag string, props map[string]string) (bool, error) {
 	prop, err := getProperty(props, r.Property)
 	if err != nil {
 		return false, err

--- a/flags_test.go
+++ b/flags_test.go
@@ -56,9 +56,9 @@ func TestParseFlagsCSV(t *testing.T) {
 					true,
 					[]Rule{
 						RateRule{
-							Rate: 0.5,
+							Rate:    0.5,
 							OnMatch: "on",
-							OnMiss: "off",
+							OnMiss:  "off",
 						},
 					},
 				},
@@ -223,7 +223,7 @@ func TestMultipleDefinitions(t *testing.T) {
 	RefreshFlags(backend)
 
 	flag := flags[repeatedFlag]
-	assert.Equal(t, flag, Flag{repeatedFlag, true, []Rule{RateRule{Rate: lastValue, OnMatch: "on", OnMiss: "off",}}})
+	assert.Equal(t, flag, Flag{repeatedFlag, true, []Rule{RateRule{Rate: lastValue, OnMatch: "on", OnMiss: "off"}}})
 
 }
 

--- a/flags_test.go
+++ b/flags_test.go
@@ -172,6 +172,16 @@ func BenchmarkEnabled(b *testing.B) {
 	}
 }
 
+// assertFlagsEqual is a helper function for asserting
+// that two maps of flags are equal
+func assertFlagsEqual(t *testing.T, expected, actual map[string]Flag) {
+	assert.Equal(t, len(expected), len(actual))
+
+	for k, v := range expected {
+		assert.Equal(t, v, actual[k])
+	}
+}
+
 func TestOverride(t *testing.T) {
 	t.Parallel()
 

--- a/flags_test.go
+++ b/flags_test.go
@@ -471,7 +471,7 @@ func TestDefaultTags(t *testing.T) {
 	t.Parallel()
 
 	const iterations = 100000
-	g, _ := testGoforit(DefaultInterval, &dummyDefaultFlagsBackend{})
+	g, buf := testGoforit(DefaultInterval, &dummyDefaultFlagsBackend{})
 	defer g.Close()
 
 	// if no properties passed, and no default tags added, then should return false
@@ -494,6 +494,14 @@ func TestDefaultTags(t *testing.T) {
 	g.AddDefaultTags(map[string]string{"cluster": "northwest-01"})
 	assert.True(t, g.Enabled(context.Background(), "test", map[string]string{"host_name": "apibox_001", "db": "mongo-prod"}))
 
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	assert.True(t, len(lines) == 6)
+	for i, line := range lines {
+		if i%2 == 1 {
+			assert.Contains(t, line, "No property")
+			assert.Contains(t, line, "in properties map or default tags")
+		}
+	}
 }
 
 func TestOverride(t *testing.T) {
@@ -660,7 +668,7 @@ func TestRefreshCycleMetric(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		v := values[i]
 		// Should be ~< 10ms
-		assert.InDelta(t, 0.005, v, 0.010)
+		assert.InDelta(t, 0.007, v, 0.015)
 	}
 
 	last := math.Inf(-1)

--- a/flags_test.go
+++ b/flags_test.go
@@ -172,16 +172,6 @@ func BenchmarkEnabled(b *testing.B) {
 	}
 }
 
-// assertFlagsEqual is a helper function for asserting
-// that two maps of flags are equal
-func assertFlagsEqual(t *testing.T, expected, actual map[string]Flag) {
-	assert.Equal(t, len(expected), len(actual))
-
-	for k, v := range expected {
-		assert.Equal(t, v, actual[k])
-	}
-}
-
 func TestOverride(t *testing.T) {
 	t.Parallel()
 

--- a/global.go
+++ b/global.go
@@ -23,6 +23,10 @@ func SetStalenessThreshold(threshold time.Duration) {
 	globalGoforit.SetStalenessThreshold(threshold)
 }
 
+func AddDefaultTags(tags map[string]string) {
+	globalGoforit.AddDefaultTags(tags)
+}
+
 func Init(interval time.Duration, backend Backend) {
 	globalGoforit.init(interval, backend)
 }


### PR DESCRIPTION
This is a WIP branch for complex feature flag definition. Formalizes a flag into three properties -- name, an active toggle (on/off), and an optional sequence of rules. 

Rules can be of many types -- we have a match_list and rate rule type initially. 

Rules must be able to be executed and produce a boolean value, and must specify behavior if evaluated to true or false (return true, return false, or continue to the next rule). Clients must now provide a map of properties which will be used by rules in their evaluation. 