### PR TITLE
Add map backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ func main() {
 }
 ```
 
+If you want to set feature flags in a test, you can define your flags using a
+map:
+
+```
+flags := map[string]bool{"my.flag": true}
+goforit.Init(0, goforit.BackendFromMap(flags))
+```
 
 # Status
 

--- a/backend.go
+++ b/backend.go
@@ -24,6 +24,10 @@ type jsonFileBackend struct {
 	filename string
 }
 
+type mapBackend struct {
+	flags map[string]bool
+}
+
 type flagJson struct {
 	Name   string
 	Active bool
@@ -117,6 +121,17 @@ func (b csvFileBackend) Refresh() ([]Flag, time.Time, error) {
 	return readFile(b.filename, "csv", parseFlagsCSV)
 }
 
+func (b mapBackend) Refresh() ([]Flag, time.Time, error) {
+	flags := make([]Flag, 0, len(b.flags))
+	for name, enabled := range b.flags {
+		flags = append(flags, Flag{
+			Name:   name,
+			Active: enabled,
+		})
+	}
+	return flags, time.Time{}, nil
+}
+
 func parseFlagsCSV(r io.Reader) ([]Flag, time.Time, error) {
 	// every row is guaranteed to have 2 fields
 	const FieldsPerRecord = 2
@@ -176,4 +191,10 @@ func BackendFromFile(filename string) Backend {
 // instead of CSV
 func BackendFromJSONFile(filename string) Backend {
 	return jsonFileBackend{filename}
+}
+
+// BackendFromMap creates a backend powered by a map. Useful for
+// testing.
+func BackendFromMap(flags map[string]bool) Backend {
+	return mapBackend{flags}
 }

--- a/backend_test.go
+++ b/backend_test.go
@@ -1,6 +1,7 @@
 package goforit
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -108,6 +109,15 @@ func TestParseFlagsJSON(t *testing.T) {
 			assert.Equal(t, tc.Expected, flags)
 		})
 	}
+}
+
+func TestParseFlagsString(t *testing.T) {
+	t.Parallel()
+
+	flags := map[string]bool{"go.sun.moon": true}
+	backend := BackendFromMap(flags)
+	g, _ := testGoforit(0, backend, enabledTickerInterval)
+	assert.True(t, g.Enabled(context.Background(), "go.sun.moon", nil))
 }
 
 func TestMultipleDefinitions(t *testing.T) {


### PR DESCRIPTION
I wanted to set goforit feature flags in a test, but didn't want to have to create a file to manage my goforit feature flags. The simplest way I could think of to use goforit in a test was just to define the flags using a `map[string]bool`, but I'm open to other ideas. Thoughts?