### PR TITLE
Introduce Options for pluggable logs, stats 

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -365,7 +365,7 @@ func (g *goforit) RefreshFlags(backend Backend) {
 		}
 	}
 
-	for name, _ := range deleted {
+	for name := range deleted {
 		f, ok := g.flags.Load(name)
 		if ok {
 			f.(Flag).enabledTicker.Stop()
@@ -400,7 +400,7 @@ func (g *goforit) init(interval time.Duration, backend Backend) {
 		g.ticker = ticker
 
 		go func() {
-			for _ = range ticker.C {
+			for range ticker.C {
 				g.RefreshFlags(backend)
 			}
 		}()

--- a/flags_test.go
+++ b/flags_test.go
@@ -58,13 +58,15 @@ func (m *mockStatsd) getHistogramValues(name string) []float64 {
 	return s
 }
 
+var _ StatsdClient = &mockStatsd{}
+
 // Build a goforit for testing
 // Also return the log output
 func testGoforit(interval time.Duration, backend Backend, enabledTickerInterval time.Duration) (*goforit, *bytes.Buffer) {
 	g := newWithoutInit(enabledTickerInterval)
 	g.rnd = rand.New(rand.NewSource(seed))
 	var buf bytes.Buffer
-	g.logger = log.New(&buf, "", 9)
+	g.printf = log.New(&buf, "", 9).Printf
 	g.stats = &mockStatsd{}
 
 	if backend != nil {

--- a/flags_test.go
+++ b/flags_test.go
@@ -238,7 +238,7 @@ type dummyRulesBackend struct{}
 
 func (b *dummyRulesBackend) Refresh() ([]Flag, time.Time, error) {
 	var flags = []Flag{
-		Flag{
+		{
 			"test1",
 			true,
 			[]RuleInfo{
@@ -246,7 +246,7 @@ func (b *dummyRulesBackend) Refresh() ([]Flag, time.Time, error) {
 			},
 			nil,
 		},
-		Flag{
+		{
 			"test2",
 			true,
 			[]RuleInfo{
@@ -254,7 +254,7 @@ func (b *dummyRulesBackend) Refresh() ([]Flag, time.Time, error) {
 			},
 			nil,
 		},
-		Flag{
+		{
 			"test3",
 			true,
 			[]RuleInfo{
@@ -263,7 +263,7 @@ func (b *dummyRulesBackend) Refresh() ([]Flag, time.Time, error) {
 			},
 			nil,
 		},
-		Flag{
+		{
 			"test4",
 			true,
 			[]RuleInfo{
@@ -272,7 +272,7 @@ func (b *dummyRulesBackend) Refresh() ([]Flag, time.Time, error) {
 			},
 			nil,
 		},
-		Flag{
+		{
 			"test5",
 			true,
 			[]RuleInfo{
@@ -281,7 +281,7 @@ func (b *dummyRulesBackend) Refresh() ([]Flag, time.Time, error) {
 			},
 			nil,
 		},
-		Flag{
+		{
 			"test6",
 			true,
 			[]RuleInfo{
@@ -291,7 +291,7 @@ func (b *dummyRulesBackend) Refresh() ([]Flag, time.Time, error) {
 			},
 			nil,
 		},
-		Flag{
+		{
 			"test7",
 			true,
 			[]RuleInfo{
@@ -301,7 +301,7 @@ func (b *dummyRulesBackend) Refresh() ([]Flag, time.Time, error) {
 			},
 			nil,
 		},
-		Flag{
+		{
 			"test8",
 			true,
 			[]RuleInfo{
@@ -311,7 +311,7 @@ func (b *dummyRulesBackend) Refresh() ([]Flag, time.Time, error) {
 			},
 			nil,
 		},
-		Flag{
+		{
 			"test9",
 			true,
 			[]RuleInfo{
@@ -321,7 +321,7 @@ func (b *dummyRulesBackend) Refresh() ([]Flag, time.Time, error) {
 			},
 			nil,
 		},
-		Flag{
+		{
 			"test10",
 			true,
 			[]RuleInfo{
@@ -331,13 +331,13 @@ func (b *dummyRulesBackend) Refresh() ([]Flag, time.Time, error) {
 			},
 			nil,
 		},
-		Flag{
+		{
 			"test11",
 			true,
 			[]RuleInfo{},
 			nil,
 		},
-		Flag{
+		{
 			"test12",
 			false,
 			[]RuleInfo{


### PR DESCRIPTION
The default logging and metrics emission make choices which might not
agree with other projects, such as connecting to statsd on
a non-standard port.

Let's teach Goforit to be configurable at instantiation via the Option
pattern[0].

[0] https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis