### PR TITLE
Passing options to global Init

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -80,10 +80,7 @@ func newWithoutInit(enabledTickerInterval time.Duration) *goforit {
 // New creates a new goforit
 func New(interval time.Duration, backend Backend, opts ...Option) *goforit {
 	g := newWithoutInit(enabledTickerInterval)
-	for _, opt := range opts {
-		opt.apply(g)
-	}
-	g.init(interval, backend)
+	g.init(interval, backend, opts...)
 	return g
 }
 
@@ -424,7 +421,12 @@ func (g *goforit) AddDefaultTags(tags map[string]string) {
 
 // init initializes the flag backend, using the provided refresh function
 // to update the internal cache of flags periodically, at the specified interval.
-func (g *goforit) init(interval time.Duration, backend Backend) {
+// Applies passed initialization options to the goforit instance.
+func (g *goforit) init(interval time.Duration, backend Backend, opts ...Option) {
+	for _, opt := range opts {
+		opt.apply(g)
+	}
+
 	g.RefreshFlags(backend)
 	if interval != 0 {
 		ticker := time.NewTicker(interval)

--- a/flags_test.go
+++ b/flags_test.go
@@ -62,7 +62,7 @@ var _ StatsdClient = &mockStatsd{}
 
 // Build a goforit for testing
 // Also return the log output
-func testGoforit(interval time.Duration, backend Backend, enabledTickerInterval time.Duration) (*goforit, *bytes.Buffer) {
+func testGoforit(interval time.Duration, backend Backend, enabledTickerInterval time.Duration, options ...Option) (*goforit, *bytes.Buffer) {
 	g := newWithoutInit(enabledTickerInterval)
 	g.rnd = rand.New(rand.NewSource(seed))
 	var buf bytes.Buffer
@@ -70,7 +70,7 @@ func testGoforit(interval time.Duration, backend Backend, enabledTickerInterval 
 	g.stats = &mockStatsd{}
 
 	if backend != nil {
-		g.init(interval, backend)
+		g.init(interval, backend, options...)
 	}
 
 	return g, &buf
@@ -86,6 +86,16 @@ func TestGlobal(t *testing.T) {
 
 	assert.False(t, Enabled(nil, "go.sun.money", nil))
 	assert.True(t, Enabled(nil, "go.moon.mercury", nil))
+}
+
+func TestGlobalInitOptions(t *testing.T) {
+	// Not parallel, testing global behavior
+	backend := BackendFromFile(filepath.Join("fixtures", "flags_example.csv"))
+	stats := &mockStatsd{}
+	Init(DefaultInterval, backend, Statsd(stats))
+	defer Close()
+
+	assert.Equal(t, stats, globalGoforit.stats)
 }
 
 func TestEnabled(t *testing.T) {

--- a/global.go
+++ b/global.go
@@ -27,8 +27,8 @@ func AddDefaultTags(tags map[string]string) {
 	globalGoforit.AddDefaultTags(tags)
 }
 
-func Init(interval time.Duration, backend Backend) {
-	globalGoforit.init(interval, backend)
+func Init(interval time.Duration, backend Backend, opts ...Option) {
+	globalGoforit.init(interval, backend, opts...)
 }
 
 func Close() error {


### PR DESCRIPTION
We need to implement a custom StatsdClient and there is not way to set it for the global client. 

Another option, https://github.com/stripe/goforit/pull/17 introduced pluggable options for creating a new `goforit` instance with custom options. This PR just enables global init to accept these options.