### PR TITLE
Replacing math/rand with crypto/rand

### DIFF
--- a/flags_test.go
+++ b/flags_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"math"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"strings"
@@ -64,7 +63,6 @@ var _ StatsdClient = &mockStatsd{}
 // Also return the log output
 func testGoforit(interval time.Duration, backend Backend, enabledTickerInterval time.Duration, options ...Option) (*goforit, *bytes.Buffer) {
 	g := newWithoutInit(enabledTickerInterval)
-	g.rnd = rand.New(rand.NewSource(seed))
 	var buf bytes.Buffer
 	g.printf = log.New(&buf, "", 9).Printf
 	g.stats = &mockStatsd{}


### PR DESCRIPTION
Addresses:  https://github.com/stripe/goforit/issues/8

Before (with `math/rand`):
**Run1:**
```
goos: darwin
goarch: amd64
pkg: github.com/stripe/goforit
BenchmarkEnabled50-4    	 5000000	       263 ns/op
BenchmarkEnabled100-4   	20000000	        96.7 ns/op
PASS
ok  	github.com/stripe/goforit	3.846s
```
**Run2:**
```
goos: darwin
goarch: amd64
pkg: github.com/stripe/goforit
BenchmarkEnabled50-4    	 5000000	       273 ns/op
BenchmarkEnabled100-4   	20000000	        97.6 ns/op
PASS
ok  	github.com/stripe/goforit	3.930s
```

After (with `crypto/rand`):
**Run1:**
```
goos: darwin
goarch: amd64
pkg: github.com/stripe/goforit
BenchmarkEnabled50-4    	 1000000	      1461 ns/op
BenchmarkEnabled100-4   	20000000	        89.6 ns/op
PASS
ok  	github.com/stripe/goforit	3.765s
```
**Run2**
```
goos: darwin
goarch: amd64
pkg: github.com/stripe/goforit
BenchmarkEnabled50-4    	 1000000	      1444 ns/op
BenchmarkEnabled100-4   	20000000	        86.4 ns/op
PASS
ok  	github.com/stripe/goforit	3.607s
```