### PR TITLE
Support "feature flags v2"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ language: go
 
 go:
   - 1.x
-  - 1.9
-  - '1.10'
+  - 1.13.x
   - tip
 
 script: go test -v -bench Bench ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10
+FROM golang:1.13.5
 MAINTAINER The Stripe Observability Team <support@stripe.com>
 
 RUN mkdir -p /build

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ goforit is an experimental, quick-and-dirty client library for feature flags in 
 
 # Backends
 
-Feature flags can be stored in any desired backend. goforit provides a flatfile implementation out-of-the-box, so feature flags can be defined in a [CSV][CSV] file.
+Feature flags can be stored in any desired backend. goforit provides a several flatfile implementations out-of-the-box, so feature flags can be defined in a JSON or CSV file. See below for details.    
 
 Alternatively, flags can be stored in a key-value store like Consul or Redis.
 
@@ -37,9 +37,27 @@ func main() {
 }
 ```
 
+# Backends
+
+Included flatfile backends are:
+
+## CSV
+
+This is a very simple backend, where every row defines a flag name and a rate at which it should be enabled, between zero and one. Initialize this backend with `BackendFromFile`. See [an example][CSV].
+
+## JSON v1
+
+This backend allows each flag to have multiple rules, like a series of if-statements. Each call to `.Enabled()` takes a map of properties, which rules can match against. Each rule's matching or non-matching can cause the overall flag to be on or off, or can fallthrough to the next rule. See [the proposal for this system][JSON1_proposal] or [an example JSON file][JSON1]. It's a bit confusing to understand.
+
+## JSON v2
+
+In this format, each flag can have a number of rules, and each rule can contain a number of predicates for matching properties. When a flag is evaluated, it uses the first rule whose predicates match the given properties. See [an example JSON file, that also includes test cases][JSON2].
 
 # Status
 
 goforit is in an experimental state and may introduce breaking changes without notice.
 
 [CSV]: https://github.com/stripe/goforit/blob/master/fixtures/flags_example.csv
+[JSON1_proposal]: https://github.com/stripe/goforit/blob/master/doc/rule_flags.md
+[JSON1]: https://github.com/stripe/goforit/blob/master/fixtures/flags_example.json
+[JSON2]: https://github.com/stripe/goforit/blob/master/fixtures/flags2_acceptance.json

--- a/backend.go
+++ b/backend.go
@@ -24,6 +24,10 @@ type jsonFileBackend struct {
 	filename string
 }
 
+type jsonFileBackend2 struct {
+	filename string
+}
+
 type flagJson struct {
 	Name   string
 	Active bool

--- a/backend.go
+++ b/backend.go
@@ -37,8 +37,8 @@ type ruleInfoJson struct {
 	OnMiss  RuleAction `json:"on_miss"`
 }
 
-type JSONFormat struct {
-	Flags       []Flag  `json:"flags"`
+type JSONFormat1 struct {
+	Flags       []Flag1 `json:"flags"`
 	UpdatedTime float64 `json:"updated"`
 }
 
@@ -46,7 +46,7 @@ type JSONFormat struct {
 //simple flags that specify only Name and Rate (at least for the time being).Instead of using
 // versions to formalize this, we will write some simple logic in a custom Unmarshaler to handle
 // both cases
-func (ri *Flag) UnmarshalJSON(buf []byte) error {
+func (ri *Flag1) UnmarshalJSON(buf []byte) error {
 	var raw flagJson
 	err := json.Unmarshal(buf, &raw)
 	if err != nil {
@@ -140,7 +140,7 @@ func parseFlagsCSV(r io.Reader) ([]Flag, time.Time, error) {
 			rate = 0
 		}
 
-		f := Flag{
+		f := Flag1{
 			Name:   name,
 			Active: true,
 		}
@@ -156,12 +156,18 @@ func parseFlagsCSV(r io.Reader) ([]Flag, time.Time, error) {
 
 func parseFlagsJSON(r io.Reader) ([]Flag, time.Time, error) {
 	dec := json.NewDecoder(r)
-	var v JSONFormat
+	var v JSONFormat1
 	err := dec.Decode(&v)
 	if err != nil {
 		return nil, time.Time{}, err
 	}
-	return v.Flags, time.Unix(int64(v.UpdatedTime), 0), nil
+
+	flags := make([]Flag, len(v.Flags))
+	for i, f := range v.Flags {
+		flags[i] = f
+	}
+
+	return flags, time.Unix(int64(v.UpdatedTime), 0), nil
 }
 
 // BackendFromFile is a helper function that creates a valid

--- a/backend_test.go
+++ b/backend_test.go
@@ -24,17 +24,17 @@ func TestParseFlagsCSV(t *testing.T) {
 			Name:     "BasicExample",
 			Filename: filepath.Join("fixtures", "flags_example.csv"),
 			Expected: []Flag{
-				{
+				Flag1{
 					"go.sun.money",
 					true,
 					[]RuleInfo{{&RateRule{Rate: 0}, RuleOn, RuleOff}},
 				},
-				{
+				Flag1{
 					"go.moon.mercury",
 					true,
 					nil,
 				},
-				{
+				Flag1{
 					"go.stars.money",
 					true,
 					[]RuleInfo{{&RateRule{Rate: 0.5}, RuleOn, RuleOff}},
@@ -72,7 +72,7 @@ func TestParseFlagsJSON(t *testing.T) {
 			Name:     "BasicExample",
 			Filename: filepath.Join("fixtures", "flags_example.json"),
 			Expected: []Flag{
-				{
+				Flag1{
 					"go.sun.moon",
 					true,
 					[]RuleInfo{
@@ -81,7 +81,7 @@ func TestParseFlagsJSON(t *testing.T) {
 						{&RateRule{0.01, []string{"cluster", "db"}}, RuleOn, RuleOff},
 					},
 				},
-				{
+				Flag1{
 					"go.sun.mercury",
 					true,
 					[]RuleInfo{
@@ -118,6 +118,6 @@ func TestMultipleDefinitions(t *testing.T) {
 	f, ok := g.flags.Load(repeatedFlag)
 	assert.True(t, ok)
 	flag := f.(flagHolder).flag
-	assert.Equal(t, flag, Flag{repeatedFlag, true, []RuleInfo{{&RateRule{Rate: lastValue}, RuleOn, RuleOff}}})
+	assert.Equal(t, flag, Flag1{repeatedFlag, true, []RuleInfo{{&RateRule{Rate: lastValue}, RuleOn, RuleOff}}})
 
 }

--- a/backend_test.go
+++ b/backend_test.go
@@ -28,19 +28,16 @@ func TestParseFlagsCSV(t *testing.T) {
 					"go.sun.money",
 					true,
 					[]RuleInfo{{&RateRule{Rate: 0}, RuleOn, RuleOff}},
-					nil,
 				},
 				{
 					"go.moon.mercury",
 					true,
-					nil,
 					nil,
 				},
 				{
 					"go.stars.money",
 					true,
 					[]RuleInfo{{&RateRule{Rate: 0.5}, RuleOn, RuleOff}},
-					nil,
 				},
 			},
 		},
@@ -83,7 +80,6 @@ func TestParseFlagsJSON(t *testing.T) {
 						{&MatchListRule{"host_name", []string{"apibox_789"}}, RuleOn, RuleContinue},
 						{&RateRule{0.01, []string{"cluster", "db"}}, RuleOn, RuleOff},
 					},
-					nil,
 				},
 				{
 					"go.sun.mercury",
@@ -91,7 +87,6 @@ func TestParseFlagsJSON(t *testing.T) {
 					[]RuleInfo{
 						{&RateRule{Rate: 0.5}, RuleOn, RuleOff},
 					},
-					nil,
 				},
 			},
 		},
@@ -122,8 +117,7 @@ func TestMultipleDefinitions(t *testing.T) {
 
 	f, ok := g.flags.Load(repeatedFlag)
 	assert.True(t, ok)
-	flag := f.(Flag)
-	flag.enabledTicker = nil // we don't compare about comparing this
-	assert.Equal(t, flag, Flag{repeatedFlag, true, []RuleInfo{{&RateRule{Rate: lastValue}, RuleOn, RuleOff}}, nil})
+	flag := f.(flagHolder).flag
+	assert.Equal(t, flag, Flag{repeatedFlag, true, []RuleInfo{{&RateRule{Rate: lastValue}, RuleOn, RuleOff}}})
 
 }

--- a/fixtures/flags2_acceptance.json
+++ b/fixtures/flags2_acceptance.json
@@ -1,0 +1,154 @@
+{
+  "version": 1,
+  "flags": [
+    {
+      "name": "off_flag",
+      "_id": "ff_1",
+      "seed": "seed_1",
+      "rules": []
+    },
+    {
+      "name": "on_flag",
+      "_id": "ff_2",
+      "seed": "seed_1",
+      "rules": [
+        {"hash_by": "token", "percent": 1.0, "predicates": []}
+      ]
+    },
+    {
+      "name": "random_by_token_flag",
+      "_id": "ff_3",
+      "seed": "seed_1",
+      "rules": [
+        {"hash_by": "token", "percent": 0.2, "predicates": []}
+      ]
+    },
+    {
+      "name": "random_by_token_flag_same_seed_increased_percent",
+      "_id": "ff_3",
+      "seed": "seed_1",
+      "rules": [
+        {"hash_by": "token", "percent": 0.8, "predicates": []}
+      ]
+    },
+    {
+      "name": "random_by_token_flag_different_seed",
+      "_id": "ff_4",
+      "seed": "seed_X",
+      "rules": [
+        {"hash_by": "token", "percent": 0.2, "predicates": []}
+      ]
+    },
+    {
+      "name": "blacklist_whitelist_by_token",
+      "_id": "ff_5",
+      "seed": "seed_1",
+      "rules": [
+        {"hash_by": "token", "percent": 0.0, "predicates": [
+          {"attribute": "token", "operation": "in", "values": ["id_1", "id_2"]}
+        ]},
+        {"hash_by": "token", "percent": 1.0, "predicates": [
+          {"attribute": "token", "operation": "in", "values": ["id_2", "id_3"]}
+        ]}
+      ]
+    },
+    {
+      "name": "country_ban",
+      "_id": "ff_5",
+      "seed": "seed_1",
+      "rules": [
+        {"hash_by": "token", "percent": 1.0, "predicates": [
+          {"attribute": "token", "operation": "in", "values": ["id_1", "id_2"]},
+          {"attribute": "country", "operation": "not_in", "values": ["KP", "IR"]}
+        ]}
+      ]
+    },
+    {
+      "name": "off_flag_edge_override_on",
+      "_id": "ff_6",
+      "seed": "seed_1",
+      "rules": [],
+      "edge_override": true
+    },
+    {
+      "name": "off_flag_edge_override_off",
+      "_id": "ff_6",
+      "seed": "seed_1",
+      "rules": [],
+      "edge_override": false
+    },
+    {
+      "name": "bail_if_null_else_on",
+      "_id": "ff_5",
+      "seed": "seed_1",
+      "rules": [
+        {"hash_by": "token", "percent": 0.0, "predicates": [
+          {"attribute": "token", "operation": "is_nil", "values": []}
+        ]},
+        {"hash_by": "token", "percent": 1.0, "predicates": []}
+      ]
+    }
+  ],
+
+  "test_cases": [
+    {"flag": "off_flag", "expected": false, "attrs": {"token" : "x"}, "message": "always off"},
+    {"flag": "off_flag", "expected": false, "attrs": {"token" : "x", "foo" : "bar"}, "message": "always off, ignores attrs"},
+    {"flag": "off_flag", "expected": false, "attrs": {}, "message": "always off, ignores attrs, even when there are none"},
+
+    {"flag": "on_flag", "expected": true, "attrs": {"token": "x"}, "message": "always on"},
+    {"flag": "on_flag", "expected": true, "attrs": {"token": "x", "foo" : "bar"}, "message": "always on, ignores attrs"},
+    {"flag": "on_flag", "expected": true, "attrs": {}, "message": "always on, ignores attrs, even when there are none"},
+
+    {"flag": "random_by_token_flag", "expected": false, "attrs": {}},
+    {"flag": "random_by_token_flag", "expected": false, "attrs": {"token" : null}},
+    {"flag": "random_by_token_flag", "expected": false, "attrs": {"token" : "0"}},
+    {"flag": "random_by_token_flag", "expected": false, "attrs": {"token" : "1"}},
+    {"flag": "random_by_token_flag", "expected": true, "attrs": {"token" : "2"}},
+    {"flag": "random_by_token_flag", "expected": false, "attrs": {"token" : "3"}},
+    {"flag": "random_by_token_flag", "expected": true, "attrs": {"token" : "4"}},
+    {"flag": "random_by_token_flag", "expected": true, "attrs": {"token" : "5"}},
+    {"flag": "random_by_token_flag", "expected": false, "attrs": {"token" : "6"}},
+    {"flag": "random_by_token_flag", "expected": false, "attrs": {"token" : "7"}},
+    {"flag": "random_by_token_flag", "expected": false, "attrs": {"token" : "8"}},
+    {"flag": "random_by_token_flag", "expected": false, "attrs": {"token" : "9"}},
+
+
+    {"flag": "random_by_token_flag_same_seed_increased_percent", "expected": true, "attrs": {"token" : "0"}},
+    {"flag": "random_by_token_flag_same_seed_increased_percent", "expected": true, "attrs": {"token" : "1"}},
+    {"flag": "random_by_token_flag_same_seed_increased_percent", "expected": true, "attrs": {"token" : "2"}},
+    {"flag": "random_by_token_flag_same_seed_increased_percent", "expected": true, "attrs": {"token" : "3"}},
+    {"flag": "random_by_token_flag_same_seed_increased_percent", "expected": true, "attrs": {"token" : "4"}},
+    {"flag": "random_by_token_flag_same_seed_increased_percent", "expected": true, "attrs": {"token" : "5"}},
+    {"flag": "random_by_token_flag_same_seed_increased_percent", "expected": true, "attrs": {"token" : "6"}},
+    {"flag": "random_by_token_flag_same_seed_increased_percent", "expected": false, "attrs": {"token" : "7"}},
+    {"flag": "random_by_token_flag_same_seed_increased_percent", "expected": true, "attrs": {"token" : "8"}},
+    {"flag": "random_by_token_flag_same_seed_increased_percent", "expected": true, "attrs": {"token" : "9"}},
+
+    {"flag": "random_by_token_flag_different_seed", "expected": true, "attrs": {"token" : "0"}},
+    {"flag": "random_by_token_flag_different_seed", "expected": false, "attrs": {"token" : "1"}},
+    {"flag": "random_by_token_flag_different_seed", "expected": false, "attrs": {"token" : "2"}},
+    {"flag": "random_by_token_flag_different_seed", "expected": true, "attrs": {"token" : "3"}},
+    {"flag": "random_by_token_flag_different_seed", "expected": false, "attrs": {"token" : "4"}},
+    {"flag": "random_by_token_flag_different_seed", "expected": true, "attrs": {"token" : "5"}},
+    {"flag": "random_by_token_flag_different_seed", "expected": false, "attrs": {"token" : "6"}},
+    {"flag": "random_by_token_flag_different_seed", "expected": false, "attrs": {"token" : "7"}},
+    {"flag": "random_by_token_flag_different_seed", "expected": false, "attrs": {"token" : "8"}},
+    {"flag": "random_by_token_flag_different_seed", "expected": false, "attrs": {"token" : "9"}},
+
+    {"flag": "blacklist_whitelist_by_token", "expected": false, "attrs": {"token" : null}, "message": "null id"},
+    {"flag": "blacklist_whitelist_by_token", "expected": false, "attrs": {"token" : "id_1"}, "message": "blacklisted id"},
+    {"flag": "blacklist_whitelist_by_token", "expected": false, "attrs": {"token" : "id_2"}, "message": "blacklist evaluated first"},
+    {"flag": "blacklist_whitelist_by_token", "expected": true, "attrs": {"token" : "id_3"}, "message": "whitelist id"},
+    {"flag": "blacklist_whitelist_by_token", "expected": false, "attrs": {"token" : "id_X"}, "message": "false if neither"},
+
+    {"flag": "country_ban", "expected": false, "attrs": {"token" : "id_1", "country": "IR"}, "message": "banned country"},
+    {"flag": "country_ban", "expected": true, "attrs": {"token" : "id_1", "country": "US"}, "message": "allowed country, in whitelist"},
+    {"flag": "country_ban", "expected": false, "attrs": {"token" : "id_X", "country": "US"}, "message": "allowed country, not in whitelist"},
+
+    {"flag": "off_flag_edge_override_on", "expected": false, "attrs": {"token" : "x", "foo" : "bar"}, "message": "always off, edge_override present only for validation"},
+    {"flag": "off_flag_edge_override_off", "expected": false, "attrs": {"token" : "x", "foo" : "bar"}, "message": "always off, edge_override present only for validation"},
+
+    {"flag": "bail_if_null_else_on", "expected": false, "attrs": {"token" : null}},
+    {"flag": "bail_if_null_else_on", "expected": true, "attrs": {"token" : "foo"}}
+  ]
+}

--- a/fixtures/flags2_example.json
+++ b/fixtures/flags2_example.json
@@ -1,0 +1,24 @@
+{
+  "version": 1,
+  "flags": [
+    {
+      "name": "off_flag",
+      "_id": "ff_1",
+      "seed": "seed_1",
+      "rules": []
+    },
+    {
+      "name": "flag5",
+      "_id": "ff_5",
+      "seed": "seed_1",
+      "rules": [
+        {"hash_by": "token", "percent": 1.0, "predicates": [
+          {"attribute": "token", "operation": "in", "values": ["id_1", "id_2"]},
+          {"attribute": "country", "operation": "not_in", "values": ["KP"]}
+        ]},
+        {"hash_by": "token", "percent": 0.5, "predicates": []}
+      ]
+    }
+  ],
+  "updated": 1584642857.7121534
+}

--- a/fixtures/flags2_example.json
+++ b/fixtures/flags2_example.json
@@ -8,6 +8,22 @@
       "rules": []
     },
     {
+      "name": "go.moon.mercury",
+      "_id:": "ff_2",
+      "seed": "seed_1",
+      "rules": [
+        {"hash_by": "_random", "percent": 1.0, "predicates": []}
+      ]
+    },
+    {
+      "name": "go.stars.money",
+      "_id:": "ff_3",
+      "seed": "seed_1",
+      "rules": [
+        {"hash_by": "_random", "percent": 0.5, "predicates": []}
+      ]
+    },
+    {
       "name": "flag5",
       "_id": "ff_5",
       "seed": "seed_1",

--- a/flags.go
+++ b/flags.go
@@ -2,139 +2,18 @@ package goforit
 
 import (
 	"bytes"
-	"context"
 	"crypto/sha1"
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"log"
 	"math/rand"
-	"os"
 	"sort"
-	"sync"
-	"sync/atomic"
-	"time"
-
-	"github.com/DataDog/datadog-go/statsd"
 )
-
-// The default statsd address to emit metrics to.
-const DefaultStatsdAddr = "127.0.0.1:8200"
-
-const lastAssertInterval = 5 * time.Minute
-
-const enabledTickerInterval = 10 * time.Second
-
-// StatsdClient is the set of methods required to emit metrics to statsd, for
-// customizing behavior or mocking.
-type StatsdClient interface {
-	Histogram(string, float64, []string, float64) error
-	Gauge(string, float64, []string, float64) error
-	Count(string, int64, []string, float64) error
-	SimpleServiceCheck(string, statsd.ServiceCheckStatus) error
-}
-
-// Goforit is the main interface for the library to check if flags enabled, refresh flags
-// customizing behavior or mocking.
-type Goforit interface {
-	Enabled(ctx context.Context, name string, props map[string]string) (enabled bool)
-	RefreshFlags(backend Backend)
-	SetStalenessThreshold(threshold time.Duration)
-	AddDefaultTags(tags map[string]string)
-	Close() error
-}
-
-type goforit struct {
-	ticker *time.Ticker
-
-	stalenessMtx       sync.RWMutex
-	stalenessThreshold time.Duration
-
-	flags sync.Map
-
-	enabledTickerInterval time.Duration
-	// If a flag doesn't exist, this shared ticker will be used.
-	enabledTicker *time.Ticker
-
-	// Unix time in nanos.
-	lastFlagRefreshTime int64
-
-	defaultTags sync.Map
-
-	stats StatsdClient
-
-	// Last time we alerted that flags may be out of date
-	lastAssertMtx sync.Mutex
-	lastAssert    time.Time
-
-	// rand is not concurrency safe, in general
-	rndMtx sync.Mutex
-	rnd    *rand.Rand
-
-	printf func(msg string, args ...interface{})
-}
-
-const DefaultInterval = 30 * time.Second
-
-func newWithoutInit(enabledTickerInterval time.Duration) *goforit {
-	stats, _ := statsd.New(DefaultStatsdAddr)
-	return &goforit{
-		stats:                 stats,
-		enabledTickerInterval: enabledTickerInterval,
-		enabledTicker:         time.NewTicker(enabledTickerInterval),
-		rnd:                   rand.New(rand.NewSource(time.Now().UnixNano())),
-		printf:                log.New(os.Stderr, "[goforit] ", log.LstdFlags).Printf,
-	}
-}
-
-// New creates a new goforit
-func New(interval time.Duration, backend Backend, opts ...Option) Goforit {
-	g := newWithoutInit(enabledTickerInterval)
-	g.init(interval, backend, opts...)
-	return g
-}
-
-type Option interface {
-	apply(g *goforit)
-}
-
-type optionFunc func(g *goforit)
-
-func (o optionFunc) apply(g *goforit) {
-	o(g)
-}
-
-// Logger uses the supplied function to log errors. By default, errors are
-// written to os.Stderr.
-func Logger(printf func(msg string, args ...interface{})) Option {
-	return optionFunc(func(g *goforit) {
-		g.printf = printf
-	})
-}
-
-// Statsd uses the supplied client to emit metrics to. By default, a client is
-// created and configured to emit metrics to DefaultStatsdAddr.
-func Statsd(stats StatsdClient) Option {
-	return optionFunc(func(g *goforit) {
-		g.stats = stats
-	})
-}
-
-func (g *goforit) rand() float64 {
-	g.rndMtx.Lock()
-	defer g.rndMtx.Unlock()
-	return g.rnd.Float64()
-}
 
 type Flag struct {
 	Name   string
 	Active bool
 	Rules  []RuleInfo
-}
-
-type flagHolder struct {
-	flag          Flag
-	enabledTicker *time.Ticker
 }
 
 func (f Flag) Equal(o Flag) bool {
@@ -183,114 +62,20 @@ type RateRule struct {
 	Properties []string
 }
 
-func (g *goforit) getStalenessThreshold() time.Duration {
-	g.stalenessMtx.RLock()
-	defer g.stalenessMtx.RUnlock()
-	return g.stalenessThreshold
-}
-
-func (g *goforit) logStaleCheck() bool {
-	g.lastAssertMtx.Lock()
-	defer g.lastAssertMtx.Unlock()
-	if time.Since(g.lastAssert) < lastAssertInterval {
-		return false
-	}
-	g.lastAssert = time.Now()
-	return true
-}
-
-// Check if a time is stale.
-func (g *goforit) staleCheck(t time.Time, metric string, metricRate float64, msg string, checkLastAssert bool) {
-	if t.IsZero() {
-		// Not really useful to treat this as a real time
-		return
-	}
-
-	// Report the staleness
-	staleness := time.Since(t)
-	g.stats.Histogram(metric, staleness.Seconds(), nil, metricRate)
-
-	// Log if we're old
-	thresh := g.getStalenessThreshold()
-	if thresh == 0 {
-		return
-	}
-	if staleness <= thresh {
-		return
-	}
-	// Don't log too often!
-	if !checkLastAssert || g.logStaleCheck() {
-		g.printf(msg, staleness, thresh)
-	}
-}
-
-// Enabled returns a boolean indicating
-// whether or not the flag should be considered
-// enabled. It returns false if no flag with the specified
-// name is found
-func (g *goforit) Enabled(ctx context.Context, name string, properties map[string]string) (enabled bool) {
-	enabled = false
-	f, ok := g.flags.Load(name)
-	var flag flagHolder
-	var tickerC <-chan time.Time
-	if ok {
-		flag = f.(flagHolder)
-		tickerC = flag.enabledTicker.C
-	} else {
-		tickerC = g.enabledTicker.C
-	}
-
-	select {
-	case <-tickerC:
-		defer func() {
-			var gauge float64
-			if enabled {
-				gauge = 1
-			}
-			g.stats.Gauge("goforit.flags.enabled", gauge, []string{fmt.Sprintf("flag:%s", name)}, 1)
-			last := atomic.LoadInt64(&g.lastFlagRefreshTime)
-			// time.Duration is conveniently measured in nanoseconds.
-			lastRefreshTime := time.Unix(last/int64(time.Second), last%int64(time.Second))
-			g.staleCheck(lastRefreshTime, "goforit.flags.last_refresh_s", 1,
-				"Refresh cycle has not run in %s, past our threshold (%s)", true)
-		}()
-	default:
-	}
-
-	// Check for an override.
-	if ctx != nil {
-		if ov, ok := ctx.Value(overrideContextKey).(overrides); ok {
-			if enabled, ok = ov[name]; ok {
-				return
-			}
-		}
-	}
-
+func (flag Flag) Enabled(properties map[string]string) (bool, error) {
 	// if flag is inactive, always return false
-	if !flag.flag.Active {
-		return
+	if !flag.Active {
+		return false, nil
 	}
-
 	// if there are no rules, but flag is active, always return true
-	if len(flag.flag.Rules) == 0 {
-		enabled = true
-		return
+	if len(flag.Rules) == 0 {
+		return true, nil
 	}
 
-	mergedProperties := make(map[string]string)
-	g.defaultTags.Range(func(k, v interface{}) bool {
-		mergedProperties[k.(string)] = v.(string)
-		return true
-	})
-	for k, v := range properties {
-		mergedProperties[k] = v
-	}
-
-	for _, r := range flag.flag.Rules {
-		res, err := r.Rule.Handle(flag.flag.Name, mergedProperties)
+	for _, r := range flag.Rules {
+		res, err := r.Rule.Handle(flag.Name, properties)
 		if err != nil {
-			g.printf("error evaluating rule:\n %s", err)
-			return
+			return false, fmt.Errorf("error evaluating rule:\n %v", err)
 		}
 		var matchBehavior RuleAction
 		if res {
@@ -300,20 +85,16 @@ func (g *goforit) Enabled(ctx context.Context, name string, properties map[strin
 		}
 		switch matchBehavior {
 		case RuleOn:
-			enabled = true
-			return
+			return true, nil
 		case RuleOff:
-			enabled = false
-			return
+			return false, nil
 		case RuleContinue:
 			continue
 		default:
-			g.printf("unknown match behavior: " + string(matchBehavior))
-			return
+			return false, fmt.Errorf("unknown match behavior: " + string(matchBehavior))
 		}
 	}
-	enabled = false
-	return
+	return false, nil
 }
 
 func getProperty(props map[string]string, prop string) (string, error) {
@@ -365,132 +146,3 @@ func (r *MatchListRule) Handle(flag string, props map[string]string) (bool, erro
 	}
 	return false, nil
 }
-
-// RefreshFlags will use the provided thunk function to
-// fetch all feature flags and update the internal cache.
-// The thunk provided can use a variety of mechanisms for
-// querying the flag values, such as a local file or
-// Consul key/value storage.
-func (g *goforit) RefreshFlags(backend Backend) {
-	// Ask the backend for the flags
-	var checkStatus statsd.ServiceCheckStatus
-	defer func() {
-		g.stats.SimpleServiceCheck("goforit.refreshFlags.present", checkStatus)
-	}()
-	refreshedFlags, updated, err := backend.Refresh()
-	if err != nil {
-		checkStatus = statsd.Warn
-		g.stats.Count("goforit.refreshFlags.errors", 1, nil, 1)
-		g.printf("Error refreshing flags: %s", err)
-		return
-	}
-	atomic.StoreInt64(&g.lastFlagRefreshTime, time.Now().UnixNano())
-
-	deleted := make(map[string]bool)
-	g.flags.Range(func(name, flag interface{}) bool {
-		deleted[name.(string)] = true
-		return true
-	})
-
-	for _, flag := range refreshedFlags {
-		delete(deleted, flag.Name)
-		oldFlag, ok := g.flags.Load(flag.Name)
-		if ok {
-			// Avoid churning the map if the flag hasn't changed.
-			oldHolder := oldFlag.(flagHolder)
-			if !oldHolder.flag.Equal(flag) {
-				holder := flagHolder{flag: flag, enabledTicker: oldHolder.enabledTicker}
-				g.flags.Store(flag.Name, holder)
-			}
-		} else {
-			holder := flagHolder{flag: flag, enabledTicker: time.NewTicker(g.enabledTickerInterval)}
-			g.flags.Store(flag.Name, holder)
-		}
-	}
-
-	for name := range deleted {
-		f, ok := g.flags.Load(name)
-		if ok {
-			f.(flagHolder).enabledTicker.Stop()
-			g.flags.Delete(name)
-		}
-	}
-
-	g.staleCheck(updated, "goforit.flags.cache_file_age_s", 0.1,
-		"Backend is stale (%s) past our threshold (%s)", false)
-
-	return
-}
-
-func (g *goforit) SetStalenessThreshold(threshold time.Duration) {
-	g.stalenessMtx.Lock()
-	defer g.stalenessMtx.Unlock()
-	g.stalenessThreshold = threshold
-}
-
-func (g *goforit) AddDefaultTags(tags map[string]string) {
-	for k, v := range tags {
-		g.defaultTags.Store(k, v)
-	}
-}
-
-// init initializes the flag backend, using the provided refresh function
-// to update the internal cache of flags periodically, at the specified interval.
-// Applies passed initialization options to the goforit instance.
-func (g *goforit) init(interval time.Duration, backend Backend, opts ...Option) {
-	for _, opt := range opts {
-		opt.apply(g)
-	}
-
-	g.RefreshFlags(backend)
-	if interval != 0 {
-		ticker := time.NewTicker(interval)
-		g.ticker = ticker
-
-		go func() {
-			for range ticker.C {
-				g.RefreshFlags(backend)
-			}
-		}()
-	}
-}
-
-// A unique context key for overrides
-type overrideContextKeyType struct{}
-
-var overrideContextKey = overrideContextKeyType{}
-
-type overrides map[string]bool
-
-// Override allows overriding the value of a goforit flag within a context.
-// This is mainly useful for tests.
-func Override(ctx context.Context, name string, value bool) context.Context {
-	ov := overrides{}
-	if old, ok := ctx.Value(overrideContextKey).(overrides); ok {
-		for k, v := range old {
-			ov[k] = v
-		}
-	}
-	ov[name] = value
-	return context.WithValue(ctx, overrideContextKey, ov)
-}
-
-// Close releases resources held
-// It's still safe to call Enabled()
-func (g *goforit) Close() error {
-	if g.ticker != nil {
-		g.ticker.Stop()
-		g.ticker = nil
-
-		g.flags.Range(func(k, v interface{}) bool {
-			v.(flagHolder).enabledTicker.Stop()
-			return true
-		})
-
-		g.enabledTicker.Stop()
-	}
-	return nil
-}
-
-// for the interface compatability static check
-var _ Goforit = &goforit{}

--- a/flags.go
+++ b/flags.go
@@ -9,13 +9,28 @@ import (
 	"sort"
 )
 
-type Flag struct {
+type Flag interface {
+	FlagName() string
+	Enabled(rnd randFunc, properties map[string]string) (bool, error)
+	Equal(other Flag) bool
+}
+
+type Flag1 struct {
 	Name   string
 	Active bool
 	Rules  []RuleInfo
 }
 
-func (f Flag) Equal(o Flag) bool {
+func (f Flag1) FlagName() string {
+	return f.Name
+}
+
+func (f Flag1) Equal(other Flag) bool {
+	o, ok := other.(Flag1)
+	if !ok {
+		return false
+	}
+
 	if f.Name != o.Name || f.Active != o.Active || len(f.Rules) != len(o.Rules) {
 		return false
 	}
@@ -61,7 +76,7 @@ type RateRule struct {
 	Properties []string
 }
 
-func (flag Flag) Enabled(rnd randFunc, properties map[string]string) (bool, error) {
+func (flag Flag1) Enabled(rnd randFunc, properties map[string]string) (bool, error) {
 	// if flag is inactive, always return false
 	if !flag.Active {
 		return false, nil

--- a/flags2.go
+++ b/flags2.go
@@ -1,0 +1,29 @@
+package goforit
+
+type Operation2 string
+
+const (
+	OpIn      Operation2 = "in"
+	OpNotIn   Operation2 = "not_in"
+	OpIsNil   Operation2 = "is_nil"
+	OptNotNil Operation2 = "is_not_nil"
+)
+
+type Predicate2 struct {
+	Attribute string
+	Operation Operation2
+	Values    []string
+}
+type Rule2 struct {
+	HashBy     string `json:"hash_by"`
+	Percent    float64
+	Predicates []Predicate2
+}
+type Flag2 struct {
+	Name  string
+	Seed  string
+	Rules []Rule2
+}
+type FlagFile2 struct {
+	Flags []Flag2
+}

--- a/flags2.go
+++ b/flags2.go
@@ -89,6 +89,20 @@ func (f Flag2) Enabled(rnd randFunc, properties map[string]string) (bool, error)
 	return false, nil
 }
 
+func (f Flag2) Clamp() FlagClamp {
+	if len(f.Rules) == 0 {
+		return FlagAlwaysOff
+	}
+	if len(f.Rules) == 1 && len(f.Rules[0].Predicates) == 0 {
+		if f.Rules[0].Percent <= PercentOff {
+			return FlagAlwaysOff
+		} else if f.Rules[0].Percent >= PercentOn {
+			return FlagAlwaysOn
+		}
+	}
+	return FlagMayVary
+}
+
 func (p Predicate2) equal(o Predicate2) bool {
 	if p.Attribute != o.Attribute || p.Operation != o.Operation || len(p.Values) != len(o.Values) {
 		return false

--- a/flags2.go
+++ b/flags2.go
@@ -3,6 +3,7 @@ package goforit
 import "encoding/json"
 
 type Operation2 string
+type Attributes2 map[string]string
 
 const (
 	OpIn      Operation2 = "in"
@@ -50,7 +51,7 @@ func (p *Predicate2) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (f Flag2) Evaluate(attributes map[string]string) bool {
+func (f Flag2) Evaluate(attributes Attributes2) (bool, error) {
 	// TODO
-	return true
+	return true, nil
 }

--- a/flags2.go
+++ b/flags2.go
@@ -1,15 +1,26 @@
 package goforit
 
-import "encoding/json"
+import (
+	"crypto/sha1"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+)
 
 type Operation2 string
 type Attributes2 map[string]string
 
 const (
-	OpIn      Operation2 = "in"
-	OpNotIn   Operation2 = "not_in"
-	OpIsNil   Operation2 = "is_nil"
-	OptNotNil Operation2 = "is_not_nil"
+	OpIn      = "in"
+	OpNotIn   = "not_in"
+	OpIsNil   = "is_nil"
+	OptNotNil = "is_not_nil"
+
+	PercentOn  = 1.0
+	PercentOff = 0.0
+
+	HashByRandom = "_random"
 )
 
 type Predicate2 struct {
@@ -51,7 +62,81 @@ func (p *Predicate2) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (f Flag2) Evaluate(attributes Attributes2) (bool, error) {
-	// TODO
+func (p Predicate2) matches(attributes Attributes2) (bool, error) {
+	val, present := attributes[p.Attribute]
+	switch p.Operation {
+	case OpIn:
+		return p.Values[val], nil
+	case OpNotIn:
+		return !p.Values[val], nil
+	case OpIsNil:
+		return !present, nil
+	case OptNotNil:
+		return present, nil
+	default:
+		return false, fmt.Errorf("unknown predicate %q", p.Operation)
+	}
+}
+
+func (r Rule2) matches(attributes Attributes2) (bool, error) {
+	_, hashPresent := attributes[r.HashBy]
+	if !hashPresent && r.HashBy != HashByRandom && r.Percent > PercentOff && r.Percent < PercentOn {
+		// We have no way to calculate a percentage, so the specced behavior is to skip this rule
+		return false, nil
+	}
+
+	for _, pred := range r.Predicates {
+		match, err := pred.matches(attributes)
+		if err != nil {
+			return false, err
+		}
+		// ALL predicates must match
+		if !match {
+			return false, nil
+		}
+	}
 	return true, nil
+}
+
+func (r Rule2) hashValue(seed, val string) float64 {
+	h := sha1.New()
+	h.Write([]byte(seed))
+	h.Write([]byte("."))
+	h.Write([]byte(val))
+	sum := h.Sum(nil)
+	ival := binary.BigEndian.Uint16(sum[:])
+	return float64(ival) / float64(1<<16)
+}
+
+func (r Rule2) evaluate(seed string, attributes Attributes2) (bool, error) {
+	if r.Percent >= PercentOn {
+		return true, nil
+	}
+	if r.Percent <= PercentOff {
+		return false, nil
+	}
+
+	if r.HashBy == HashByRandom {
+		return rand.Float64() < r.Percent, nil
+	}
+
+	val := attributes[r.HashBy]
+	return r.hashValue(seed, val) < r.Percent, nil
+}
+
+func (f Flag2) Evaluate(attributes Attributes2) (bool, error) {
+	for _, rule := range f.Rules {
+		match, err := rule.matches(attributes)
+		if err != nil {
+			return false, err
+		}
+		if !match {
+			continue
+		}
+
+		return rule.evaluate(f.Seed, attributes)
+	}
+
+	// If no rules match, the flag is off
+	return false, nil
 }

--- a/flags2.go
+++ b/flags2.go
@@ -1,5 +1,7 @@
 package goforit
 
+import "encoding/json"
+
 type Operation2 string
 
 const (
@@ -12,7 +14,7 @@ const (
 type Predicate2 struct {
 	Attribute string
 	Operation Operation2
-	Values    []string
+	Values    map[string]bool
 }
 type Rule2 struct {
 	HashBy     string `json:"hash_by"`
@@ -26,6 +28,26 @@ type Flag2 struct {
 }
 type FlagFile2 struct {
 	Flags []Flag2
+}
+
+type predicate2Json struct {
+	Attribute string
+	Operation Operation2
+	Values    []string
+}
+
+func (p *Predicate2) UnmarshalJSON(data []byte) error {
+	var raw predicate2Json
+	err := json.Unmarshal(data, &raw)
+	if err != nil {
+		return err
+	}
+
+	*p = Predicate2{Attribute: raw.Attribute, Operation: raw.Operation, Values: map[string]bool{}}
+	for _, v := range raw.Values {
+		p.Values[v] = true
+	}
+	return nil
 }
 
 func (f Flag2) Evaluate(attributes map[string]string) bool {

--- a/flags2.go
+++ b/flags2.go
@@ -27,3 +27,8 @@ type Flag2 struct {
 type FlagFile2 struct {
 	Flags []Flag2
 }
+
+func (f Flag2) Evaluate(attributes map[string]string) bool {
+	// TODO
+	return true
+}

--- a/flags2_test.go
+++ b/flags2_test.go
@@ -18,63 +18,38 @@ type FlagTestCase2 struct {
 	Message  string
 }
 type FlagAcceptance2 struct {
-	FlagFile2
+	JSONFormat2
 	TestCases []FlagTestCase2 `json:"test_cases"`
 }
 
-func TestFlags2Parse(t *testing.T) {
+func TestFlags2Backend(t *testing.T) {
 	t.Parallel()
 
-	jsonText := `
-{
-  "version": 1,
-  "flags": [
-    {
-      "name": "off_flag",
-      "_id": "ff_1",
-      "seed": "seed_1",
-      "rules": []
-    },
-    {
-      "name": "flag5",
-      "_id": "ff_5",
-      "seed": "seed_1",
-      "rules": [
-        {"hash_by": "token", "percent": 1.0, "predicates": [
-          {"attribute": "token", "operation": "in", "values": ["id_1", "id_2"]},
-          {"attribute": "country", "operation": "not_in", "values": ["KP"]}
-        ]},
-        {"hash_by": "token", "percent": 0.5, "predicates": []}	
-      ]
-    }
-  ]
-}
-`
-	expected := FlagFile2{
-		Flags: []Flag2{
-			{Name: "off_flag", Seed: "seed_1", Rules: []Rule2{}},
-			{
-				Name: "flag5",
-				Seed: "seed_1",
-				Rules: []Rule2{
-					{
-						HashBy:  "token",
-						Percent: 1.0,
-						Predicates: []Predicate2{
-							{Attribute: "token", Operation: OpIn, Values: map[string]bool{"id_1": true, "id_2": true}},
-							{Attribute: "country", Operation: OpNotIn, Values: map[string]bool{"KP": true}},
-						},
+	expectedFlags := []Flag{
+		Flag2{Name: "off_flag", Seed: "seed_1", Rules: []Rule2{}},
+		Flag2{
+			Name: "flag5",
+			Seed: "seed_1",
+			Rules: []Rule2{
+				{
+					HashBy:  "token",
+					Percent: 1.0,
+					Predicates: []Predicate2{
+						{Attribute: "token", Operation: OpIn, Values: map[string]bool{"id_1": true, "id_2": true}},
+						{Attribute: "country", Operation: OpNotIn, Values: map[string]bool{"KP": true}},
 					},
-					{HashBy: "token", Percent: 0.5, Predicates: []Predicate2{}},
 				},
+				{HashBy: "token", Percent: 0.5, Predicates: []Predicate2{}},
 			},
 		},
 	}
 
-	var file FlagFile2
-	err := json.Unmarshal([]byte(jsonText), &file)
+	backend := BackendFromJSONFile2(filepath.Join("fixtures", "flags2_example.json"))
+	flags, updated, err := backend.Refresh()
+
 	assert.NoError(t, err)
-	assert.Equal(t, expected, file)
+	assert.Equal(t, expectedFlags, flags)
+	assert.Equal(t, int64(1584642857), updated.Unix())
 }
 
 func TestFlags2Acceptance(t *testing.T) {

--- a/flags2_test.go
+++ b/flags2_test.go
@@ -94,7 +94,8 @@ func TestFlags2Acceptance(t *testing.T) {
 
 	for _, tc := range acceptanceData.TestCases {
 		t.Run(tc.Message, func(t *testing.T) {
-			actual := flags[tc.Flag].Evaluate(tc.Attrs)
+			actual, err := flags[tc.Flag].Evaluate(tc.Attrs)
+			assert.NoError(t, err)
 			assert.Equal(t, tc.Expected, actual)
 		})
 	}

--- a/flags2_test.go
+++ b/flags2_test.go
@@ -106,7 +106,7 @@ func TestFlags2Acceptance(t *testing.T) {
 				}
 			}
 
-			actual, err := flags[tc.Flag].Evaluate(attrs)
+			actual, err := flags[tc.Flag].Enabled(nil, attrs)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.Expected, actual, "%q %q", tc.Flag, tc.Attrs)
 		})

--- a/flags2_test.go
+++ b/flags2_test.go
@@ -60,8 +60,8 @@ func TestFlags2Parse(t *testing.T) {
 						HashBy:  "token",
 						Percent: 1.0,
 						Predicates: []Predicate2{
-							{Attribute: "token", Operation: OpIn, Values: []string{"id_1", "id_2"}},
-							{Attribute: "country", Operation: OpNotIn, Values: []string{"KP"}},
+							{Attribute: "token", Operation: OpIn, Values: map[string]bool{"id_1": true, "id_2": true}},
+							{Attribute: "country", Operation: OpNotIn, Values: map[string]bool{"KP": true}},
 						},
 					},
 					{HashBy: "token", Percent: 0.5, Predicates: []Predicate2{}},

--- a/flags2_test.go
+++ b/flags2_test.go
@@ -96,6 +96,8 @@ func TestFlags2Acceptance(t *testing.T) {
 	for _, tc := range acceptanceData.TestCases {
 		name := fmt.Sprintf("%s:%s", tc.Flag, tc.Message)
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			// We don't distinguish between missing/nil values
 			attrs := map[string]string{}
 			for k, v := range tc.Attrs {

--- a/flags2_test.go
+++ b/flags2_test.go
@@ -1,0 +1,63 @@
+package goforit
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFlags2Parse(t *testing.T) {
+	t.Parallel()
+
+	jsonText := `
+{
+  "version": 1,
+  "flags": [
+    {
+      "name": "off_flag",
+      "_id": "ff_1",
+      "seed": "seed_1",
+      "rules": []
+    },
+    {
+      "name": "flag5",
+      "_id": "ff_5",
+      "seed": "seed_1",
+      "rules": [
+        {"hash_by": "token", "percent": 1.0, "predicates": [
+          {"attribute": "token", "operation": "in", "values": ["id_1", "id_2"]},
+          {"attribute": "country", "operation": "not_in", "values": ["KP"]}
+        ]},
+        {"hash_by": "token", "percent": 0.5, "predicates": []}	
+      ]
+    }
+  ]
+}
+`
+	expected := FlagFile2{
+		Flags: []Flag2{
+			{Name: "off_flag", Seed: "seed_1", Rules: []Rule2{}},
+			{
+				Name: "flag5",
+				Seed: "seed_1",
+				Rules: []Rule2{
+					{
+						HashBy:  "token",
+						Percent: 1.0,
+						Predicates: []Predicate2{
+							{Attribute: "token", Operation: OpIn, Values: []string{"id_1", "id_2"}},
+							{Attribute: "country", Operation: OpNotIn, Values: []string{"KP"}},
+						},
+					},
+					{HashBy: "token", Percent: 0.5, Predicates: []Predicate2{}},
+				},
+			},
+		},
+	}
+
+	var file FlagFile2
+	err := json.Unmarshal([]byte(jsonText), &file)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, file)
+}

--- a/flags2_test.go
+++ b/flags2_test.go
@@ -28,6 +28,16 @@ func TestFlags2Backend(t *testing.T) {
 	expectedFlags := []Flag{
 		Flag2{Name: "off_flag", Seed: "seed_1", Rules: []Rule2{}},
 		Flag2{
+			Name:  "go.moon.mercury",
+			Seed:  "seed_1",
+			Rules: []Rule2{{HashBy: "_random", Percent: 1.0, Predicates: []Predicate2{}}},
+		},
+		Flag2{
+			Name:  "go.stars.money",
+			Seed:  "seed_1",
+			Rules: []Rule2{{HashBy: "_random", Percent: 0.5, Predicates: []Predicate2{}}},
+		},
+		Flag2{
 			Name: "flag5",
 			Seed: "seed_1",
 			Rules: []Rule2{

--- a/flags2_test.go
+++ b/flags2_test.go
@@ -2,6 +2,7 @@ package goforit
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"testing"
@@ -13,7 +14,7 @@ import (
 type FlagTestCase2 struct {
 	Flag     string
 	Expected bool
-	Attrs    map[string]string
+	Attrs    map[string]*string
 	Message  string
 }
 type FlagAcceptance2 struct {
@@ -93,10 +94,19 @@ func TestFlags2Acceptance(t *testing.T) {
 	}
 
 	for _, tc := range acceptanceData.TestCases {
-		t.Run(tc.Message, func(t *testing.T) {
-			actual, err := flags[tc.Flag].Evaluate(tc.Attrs)
+		name := fmt.Sprintf("%s:%s", tc.Flag, tc.Message)
+		t.Run(name, func(t *testing.T) {
+			// We don't distinguish between missing/nil values
+			attrs := map[string]string{}
+			for k, v := range tc.Attrs {
+				if v != nil {
+					attrs[k] = *v
+				}
+			}
+
+			actual, err := flags[tc.Flag].Evaluate(attrs)
 			assert.NoError(t, err)
-			assert.Equal(t, tc.Expected, actual)
+			assert.Equal(t, tc.Expected, actual, "%q %q", tc.Flag, tc.Attrs)
 		})
 	}
 }

--- a/flags_test.go
+++ b/flags_test.go
@@ -248,7 +248,7 @@ func TestCascadingRules(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		flag := Flag{tc.name, tc.active, tc.rules}
+		flag := Flag1{tc.name, tc.active, tc.rules}
 		enabled, err := flag.Enabled(nil, map[string]string{})
 		assert.NoError(t, err)
 		assert.Equal(t, tc.expected, enabled, tc.name)

--- a/flags_test.go
+++ b/flags_test.go
@@ -256,7 +256,6 @@ func (b *dummyRulesBackend) Refresh() ([]Flag, time.Time, error) {
 			[]RuleInfo{
 				{&OnRule{}, RuleOn, RuleOff},
 			},
-			nil,
 		},
 		{
 			"test2",
@@ -264,7 +263,6 @@ func (b *dummyRulesBackend) Refresh() ([]Flag, time.Time, error) {
 			[]RuleInfo{
 				{&OnRule{}, RuleOff, RuleOn},
 			},
-			nil,
 		},
 		{
 			"test3",
@@ -273,7 +271,6 @@ func (b *dummyRulesBackend) Refresh() ([]Flag, time.Time, error) {
 				{&OffRule{}, RuleOn, RuleContinue},
 				{&OnRule{}, RuleOn, RuleOff},
 			},
-			nil,
 		},
 		{
 			"test4",
@@ -282,7 +279,6 @@ func (b *dummyRulesBackend) Refresh() ([]Flag, time.Time, error) {
 				{&OffRule{}, RuleOn, RuleOff},
 				{&OnRule{}, RuleOn, RuleOff},
 			},
-			nil,
 		},
 		{
 			"test5",
@@ -291,7 +287,6 @@ func (b *dummyRulesBackend) Refresh() ([]Flag, time.Time, error) {
 				{&OnRule{}, RuleContinue, RuleOn},
 				{&OffRule{}, RuleOn, RuleOff},
 			},
-			nil,
 		},
 		{
 			"test6",
@@ -301,7 +296,6 @@ func (b *dummyRulesBackend) Refresh() ([]Flag, time.Time, error) {
 				{&OffRule{}, RuleContinue, RuleOff},
 				{&OnRule{}, RuleOn, RuleOff},
 			},
-			nil,
 		},
 		{
 			"test7",
@@ -311,7 +305,6 @@ func (b *dummyRulesBackend) Refresh() ([]Flag, time.Time, error) {
 				{&OnRule{}, RuleContinue, RuleOff},
 				{&OnRule{}, RuleOn, RuleOff},
 			},
-			nil,
 		},
 		{
 			"test8",
@@ -321,7 +314,6 @@ func (b *dummyRulesBackend) Refresh() ([]Flag, time.Time, error) {
 				{&OffRule{}, RuleOn, RuleContinue},
 				{&OnRule{}, RuleOn, RuleOff},
 			},
-			nil,
 		},
 		{
 			"test9",
@@ -331,7 +323,6 @@ func (b *dummyRulesBackend) Refresh() ([]Flag, time.Time, error) {
 				{&OffRule{}, RuleOn, RuleContinue},
 				{&OffRule{}, RuleOn, RuleOff},
 			},
-			nil,
 		},
 		{
 			"test10",
@@ -341,13 +332,11 @@ func (b *dummyRulesBackend) Refresh() ([]Flag, time.Time, error) {
 				{&OffRule{}, RuleOn, RuleOff},
 				{&OnRule{}, RuleContinue, RuleOff},
 			},
-			nil,
 		},
 		{
 			"test11",
 			true,
 			[]RuleInfo{},
-			nil,
 		},
 		{
 			"test12",
@@ -355,7 +344,6 @@ func (b *dummyRulesBackend) Refresh() ([]Flag, time.Time, error) {
 			[]RuleInfo{
 				{&OnRule{}, RuleOn, RuleOn},
 			},
-			nil,
 		},
 	}
 	return flags, time.Time{}, nil
@@ -462,10 +450,10 @@ func TestRefreshTicker(t *testing.T) {
 	defer g.Close()
 
 	earthTicker := time.NewTicker(time.Nanosecond)
-	g.flags.Store("go.earth.money", Flag{"go.earth.money", true, nil, earthTicker})
+	g.flags.Store("go.earth.money", flagHolder{Flag{"go.earth.money", true, nil}, earthTicker})
 	f, ok := g.flags.Load("go.moon.mercury")
 	assert.True(t, ok)
-	moonTicker := f.(Flag).enabledTicker
+	moonTicker := f.(flagHolder).enabledTicker
 	g.flags.Delete("go.stars.money")
 	// Give tickers time to run.
 	time.Sleep(time.Millisecond)
@@ -484,7 +472,7 @@ func TestRefreshTicker(t *testing.T) {
 	// Make sure that the ticker was preserved.
 	f, ok = g.flags.Load("go.moon.mercury")
 	assert.True(t, ok)
-	assert.Equal(t, moonTicker, f.(Flag).enabledTicker)
+	assert.Equal(t, moonTicker, f.(flagHolder).enabledTicker)
 
 	// Make sure that the deleted flag's ticker was stopped.
 	_, ok = <-earthTicker.C
@@ -546,7 +534,6 @@ func (b *dummyDefaultFlagsBackend) Refresh() ([]Flag, time.Time, error) {
 			{&MatchListRule{"host_name", []string{"apibox_123", "apibox_456"}}, RuleOn, RuleContinue},
 			{&RateRule{1, []string{"cluster", "db"}}, RuleOn, RuleOff},
 		},
-		time.NewTicker(time.Second),
 	}
 	return []Flag{testFlag}, time.Time{}, nil
 }
@@ -682,7 +669,6 @@ func (b *dummyAgeBackend) Refresh() ([]Flag, time.Time, error) {
 		"go.sun.money",
 		true,
 		[]RuleInfo{},
-		time.NewTicker(time.Nanosecond),
 	}
 	b.mtx.RLock()
 	defer b.mtx.RUnlock()
@@ -742,7 +728,7 @@ func TestRefreshCycleMetric(t *testing.T) {
 
 	tickerC := make(chan time.Time, 1)
 	f, _ := g.flags.Load("go.sun.money")
-	flag := f.(Flag)
+	flag := f.(flagHolder)
 	flag.enabledTicker = &time.Ticker{C: tickerC}
 	g.flags.Store("go.sun.money", flag)
 

--- a/flags_test.go
+++ b/flags_test.go
@@ -1,129 +1,11 @@
 package goforit
 
 import (
-	"bytes"
-	"context"
-	"fmt"
-	"log"
-	"math"
-	"math/rand"
-	"os"
-	"path/filepath"
-	"strings"
-	"sync"
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-go/statsd"
 	"github.com/stretchr/testify/assert"
 )
-
-// arbitrary but fixed for reproducible testing
-const seed = 5194304667978865136
-
-const ε = .02
-
-type mockStatsd struct {
-	lock            sync.RWMutex
-	histogramValues map[string][]float64
-}
-
-func (m *mockStatsd) Gauge(string, float64, []string, float64) error {
-	return nil
-}
-
-func (m *mockStatsd) Count(string, int64, []string, float64) error {
-	return nil
-}
-
-func (m *mockStatsd) SimpleServiceCheck(string, statsd.ServiceCheckStatus) error {
-	return nil
-}
-
-func (m *mockStatsd) Histogram(name string, value float64, tags []string, rate float64) error {
-	m.lock.Lock()
-	defer m.lock.Unlock()
-	if m.histogramValues == nil {
-		m.histogramValues = make(map[string][]float64)
-	}
-	m.histogramValues[name] = append(m.histogramValues[name], value)
-	return nil
-}
-
-func (m *mockStatsd) getHistogramValues(name string) []float64 {
-	m.lock.Lock()
-	defer m.lock.Unlock()
-	s := make([]float64, len(m.histogramValues[name]))
-	copy(s, m.histogramValues[name])
-	return s
-}
-
-var _ StatsdClient = &mockStatsd{}
-
-// Build a goforit for testing
-// Also return the log output
-func testGoforit(interval time.Duration, backend Backend, enabledTickerInterval time.Duration, options ...Option) (*goforit, *bytes.Buffer) {
-	g := newWithoutInit(enabledTickerInterval)
-	g.rnd = rand.New(rand.NewSource(seed))
-	var buf bytes.Buffer
-	g.printf = log.New(&buf, "", 9).Printf
-	g.stats = &mockStatsd{}
-
-	if backend != nil {
-		g.init(interval, backend, options...)
-	}
-
-	return g, &buf
-}
-
-func TestGlobal(t *testing.T) {
-	// Not parallel, testing global behavior
-	backend := BackendFromFile(filepath.Join("fixtures", "flags_example.csv"))
-	globalGoforit.stats = &mockStatsd{} // prevent logging real metrics
-
-	Init(DefaultInterval, backend)
-	defer Close()
-
-	assert.False(t, Enabled(nil, "go.sun.money", nil))
-	assert.True(t, Enabled(nil, "go.moon.mercury", nil))
-}
-
-func TestGlobalInitOptions(t *testing.T) {
-	// Not parallel, testing global behavior
-	backend := BackendFromFile(filepath.Join("fixtures", "flags_example.csv"))
-	stats := &mockStatsd{}
-	Init(DefaultInterval, backend, Statsd(stats))
-	defer Close()
-
-	assert.Equal(t, stats, globalGoforit.stats)
-}
-
-func TestEnabled(t *testing.T) {
-	t.Parallel()
-
-	const iterations = 100000
-
-	backend := BackendFromFile(filepath.Join("fixtures", "flags_example.csv"))
-	g, _ := testGoforit(DefaultInterval, backend, enabledTickerInterval)
-	defer g.Close()
-
-	assert.False(t, g.Enabled(context.Background(), "go.sun.money", nil))
-	assert.True(t, g.Enabled(context.Background(), "go.moon.mercury", nil))
-
-	// nil is equivalent to empty context
-	assert.False(t, g.Enabled(nil, "go.sun.money", nil))
-	assert.True(t, g.Enabled(nil, "go.moon.mercury", nil))
-
-	count := 0
-	for i := 0; i < iterations; i++ {
-		if g.Enabled(context.Background(), "go.stars.money", nil) {
-			count++
-		}
-	}
-	actualRate := float64(count) / float64(iterations)
-
-	assert.InEpsilon(t, 0.5, actualRate, ε)
-}
 
 func TestMatchListRule(t *testing.T) {
 
@@ -235,592 +117,138 @@ func TestRateRule(t *testing.T) {
 	assert.Error(t, err)
 }
 
-type OnRule struct{}
-type OffRule struct{}
-
-func (r *OnRule) Handle(flag string, props map[string]string) (bool, error) {
-	return true, nil
-}
-
-func (r *OffRule) Handle(flag string, props map[string]string) (bool, error) {
-	return false, nil
-}
-
 type dummyRulesBackend struct{}
 
 func (b *dummyRulesBackend) Refresh() ([]Flag, time.Time, error) {
-	var flags = []Flag{
-		{
-			"test1",
-			true,
-			[]RuleInfo{
-				{&OnRule{}, RuleOn, RuleOff},
-			},
-		},
-		{
-			"test2",
-			true,
-			[]RuleInfo{
-				{&OnRule{}, RuleOff, RuleOn},
-			},
-		},
-		{
-			"test3",
-			true,
-			[]RuleInfo{
-				{&OffRule{}, RuleOn, RuleContinue},
-				{&OnRule{}, RuleOn, RuleOff},
-			},
-		},
-		{
-			"test4",
-			true,
-			[]RuleInfo{
-				{&OffRule{}, RuleOn, RuleOff},
-				{&OnRule{}, RuleOn, RuleOff},
-			},
-		},
-		{
-			"test5",
-			true,
-			[]RuleInfo{
-				{&OnRule{}, RuleContinue, RuleOn},
-				{&OffRule{}, RuleOn, RuleOff},
-			},
-		},
-		{
-			"test6",
-			true,
-			[]RuleInfo{
-				{&OffRule{}, RuleOff, RuleContinue},
-				{&OffRule{}, RuleContinue, RuleOff},
-				{&OnRule{}, RuleOn, RuleOff},
-			},
-		},
-		{
-			"test7",
-			true,
-			[]RuleInfo{
-				{&OffRule{}, RuleOff, RuleContinue},
-				{&OnRule{}, RuleContinue, RuleOff},
-				{&OnRule{}, RuleOn, RuleOff},
-			},
-		},
-		{
-			"test8",
-			true,
-			[]RuleInfo{
-				{&OffRule{}, RuleOff, RuleContinue},
-				{&OffRule{}, RuleOn, RuleContinue},
-				{&OnRule{}, RuleOn, RuleOff},
-			},
-		},
-		{
-			"test9",
-			true,
-			[]RuleInfo{
-				{&OffRule{}, RuleOff, RuleContinue},
-				{&OffRule{}, RuleOn, RuleContinue},
-				{&OffRule{}, RuleOn, RuleOff},
-			},
-		},
-		{
-			"test10",
-			true,
-			[]RuleInfo{
-				{&OffRule{}, RuleOn, RuleContinue},
-				{&OffRule{}, RuleOn, RuleOff},
-				{&OnRule{}, RuleContinue, RuleOff},
-			},
-		},
-		{
-			"test11",
-			true,
-			[]RuleInfo{},
-		},
-		{
-			"test12",
-			false,
-			[]RuleInfo{
-				{&OnRule{}, RuleOn, RuleOn},
-			},
-		},
-	}
+	var flags = []Flag{}
 	return flags, time.Time{}, nil
 }
 
 func TestCascadingRules(t *testing.T) {
 	t.Parallel()
 
-	g, _ := testGoforit(DefaultInterval, &dummyRulesBackend{}, enabledTickerInterval)
-	defer g.Close()
-
-	// test match on, miss off single rule
-	assert.True(t, g.Enabled(context.Background(), "test1", nil))
-
-	// test match off, miss on single rule
-	assert.False(t, g.Enabled(context.Background(), "test2", nil))
-
-	// test match on, miss continue
-	assert.True(t, g.Enabled(context.Background(), "test3", nil))
-
-	// test match on, miss off
-	assert.False(t, g.Enabled(context.Background(), "test4", nil))
-
-	// test match continue
-	assert.False(t, g.Enabled(context.Background(), "test5", nil))
-
-	// test 3 rules -- 2nd rule off
-	assert.False(t, g.Enabled(context.Background(), "test6", nil))
-
-	// test cascade to last rule (continue to last rule)
-	// must match both 2nd and 3rd rule
-	assert.True(t, g.Enabled(context.Background(), "test7", nil))
-
-	// test cascade to last rule (continue to last rule)
-	// must match either 2nd rule or 3rd rule, only 3rd on
-	assert.True(t, g.Enabled(context.Background(), "test8", nil))
-
-	// test cascade to last rule (continue to last rule)
-	// must match either 2nd or 3rd, all 3 off
-	assert.False(t, g.Enabled(context.Background(), "test9", nil))
-
-	// test default behavior is off if all rules are "continue"
-	assert.False(t, g.Enabled(context.Background(), "test10", nil))
-
-	// test default on if no rules and active = true
-	assert.True(t, g.Enabled(context.Background(), "test11", nil))
-
-	// test return false categorically if active = false
-	assert.False(t, g.Enabled(context.Background(), "test12", nil))
-}
-
-// dummyBackend lets us test the RefreshFlags
-// by returning the flags only the second time the Refresh
-// method is called
-type dummyBackend struct {
-	// tally how many times Refresh() has been called
-	refreshedCount int
-}
-
-func (b *dummyBackend) Refresh() ([]Flag, time.Time, error) {
-	defer func() {
-		b.refreshedCount++
-	}()
-
-	if b.refreshedCount == 0 {
-		return []Flag{}, time.Time{}, nil
-	}
-
-	f, err := os.Open(filepath.Join("fixtures", "flags_example.csv"))
-	if err != nil {
-		return nil, time.Time{}, err
-	}
-	defer f.Close()
-	return parseFlagsCSV(f)
-}
-
-func TestRefresh(t *testing.T) {
-	t.Parallel()
-
-	backend := &dummyBackend{}
-	g, _ := testGoforit(10*time.Millisecond, backend, enabledTickerInterval)
-
-	assert.False(t, g.Enabled(context.Background(), "go.sun.money", nil))
-	assert.False(t, g.Enabled(context.Background(), "go.moon.mercury", nil))
-
-	defer g.Close()
-
-	// ensure refresh runs twice to avoid race conditions
-	// in which the Refresh method returns but the assertions get called
-	// before the flags are actually updated
-	for backend.refreshedCount < 2 {
-		<-time.After(10 * time.Millisecond)
-	}
-
-	assert.False(t, g.Enabled(context.Background(), "go.sun.money", nil))
-	assert.True(t, g.Enabled(context.Background(), "go.moon.mercury", nil))
-}
-
-func TestRefreshTicker(t *testing.T) {
-	t.Parallel()
-
-	backend := BackendFromFile(filepath.Join("fixtures", "flags_example.csv"))
-	g, _ := testGoforit(10*time.Second, backend, enabledTickerInterval)
-	defer g.Close()
-
-	earthTicker := time.NewTicker(time.Nanosecond)
-	g.flags.Store("go.earth.money", flagHolder{Flag{"go.earth.money", true, nil}, earthTicker})
-	f, ok := g.flags.Load("go.moon.mercury")
-	assert.True(t, ok)
-	moonTicker := f.(flagHolder).enabledTicker
-	g.flags.Delete("go.stars.money")
-	// Give tickers time to run.
-	time.Sleep(time.Millisecond)
-
-	g.RefreshFlags(backend)
-
-	_, ok = g.flags.Load("go.sun.money")
-	assert.True(t, ok)
-	_, ok = g.flags.Load("go.moon.mercury")
-	assert.True(t, ok)
-	_, ok = g.flags.Load("go.stars.money")
-	assert.True(t, ok)
-	_, ok = g.flags.Load("go.earth.money")
-	assert.False(t, ok)
-
-	// Make sure that the ticker was preserved.
-	f, ok = g.flags.Load("go.moon.mercury")
-	assert.True(t, ok)
-	assert.Equal(t, moonTicker, f.(flagHolder).enabledTicker)
-
-	// Make sure that the deleted flag's ticker was stopped.
-	_, ok = <-earthTicker.C
-	assert.True(t, ok)
-	// If the ticker wasn't deleted, make sure it can run again.
-	time.Sleep(time.Millisecond)
-	select {
-	case _, ok = <-earthTicker.C:
-		// If the ticker was stopped, there's no way we'd get a 2nd tick.
-		assert.False(t, ok)
-	default:
-	}
-}
-
-// BenchmarkEnabled50 runs a benchmark for a feature flag
-// that is enabled for 50% of operations.
-func BenchmarkEnabled50(b *testing.B) {
-	backend := BackendFromFile(filepath.Join("fixtures", "flags_example.csv"))
-	g, _ := testGoforit(10*time.Millisecond, backend, enabledTickerInterval)
-	defer g.Close()
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_ = g.Enabled(context.Background(), "go.stars.money", nil)
-	}
-}
-
-// BenchmarkEnabled100 runs a benchmark for a feature flag
-// that is enabled for 100% of operations.
-func BenchmarkEnabled100(b *testing.B) {
-	backend := BackendFromFile(filepath.Join("fixtures", "flags_example.csv"))
-	g, _ := testGoforit(10*time.Millisecond, backend, enabledTickerInterval)
-	defer g.Close()
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_ = g.Enabled(context.Background(), "go.moon.mercury", nil)
-	}
-}
-
-// assertFlagsEqual is a helper function for asserting
-// that two maps of flags are equal
-func assertFlagsEqual(t *testing.T, expected, actual []Flag) {
-	assert.Equal(t, len(expected), len(actual))
-
-	for k, v := range expected {
-		assert.Equal(t, v, actual[k])
-	}
-}
-
-type dummyDefaultFlagsBackend struct{}
-
-func (b *dummyDefaultFlagsBackend) Refresh() ([]Flag, time.Time, error) {
-	var testFlag = Flag{
-		"test",
-		true,
-		[]RuleInfo{
-			{&MatchListRule{"host_name", []string{"apibox_789"}}, RuleOff, RuleContinue},
-			{&MatchListRule{"host_name", []string{"apibox_123", "apibox_456"}}, RuleOn, RuleContinue},
-			{&RateRule{1, []string{"cluster", "db"}}, RuleOn, RuleOff},
+	testCases := []struct {
+		name     string
+		active   bool
+		rules    []RuleInfo
+		expected bool
+	}{
+		{
+			"test match on, miss off single rule",
+			true,
+			[]RuleInfo{
+				{&OnRule{}, RuleOn, RuleOff},
+			},
+			true,
+		},
+		{
+			"test match off, miss on single rule",
+			true,
+			[]RuleInfo{
+				{&OnRule{}, RuleOff, RuleOn},
+			},
+			false,
+		},
+		{
+			"test match on, miss continue",
+			true,
+			[]RuleInfo{
+				{&OffRule{}, RuleOn, RuleContinue},
+				{&OnRule{}, RuleOn, RuleOff},
+			},
+			true,
+		},
+		{
+			"test match on, miss off",
+			true,
+			[]RuleInfo{
+				{&OffRule{}, RuleOn, RuleOff},
+				{&OnRule{}, RuleOn, RuleOff},
+			},
+			false,
+		},
+		{
+			"test match continue",
+			true,
+			[]RuleInfo{
+				{&OnRule{}, RuleContinue, RuleOn},
+				{&OffRule{}, RuleOn, RuleOff},
+			},
+			false,
+		},
+		{
+			"test 3 rules -- 2nd rule off",
+			true,
+			[]RuleInfo{
+				{&OffRule{}, RuleOff, RuleContinue},
+				{&OffRule{}, RuleContinue, RuleOff},
+				{&OnRule{}, RuleOn, RuleOff},
+			},
+			false,
+		},
+		{
+			"test cascade to last rule (continue to last rule)",
+			// must match both 2nd and 3rd rule
+			true,
+			[]RuleInfo{
+				{&OffRule{}, RuleOff, RuleContinue},
+				{&OnRule{}, RuleContinue, RuleOff},
+				{&OnRule{}, RuleOn, RuleOff},
+			},
+			true,
+		},
+		{
+			"test cascade to last rule (continue to last rule)",
+			// must match either 2nd rule or 3rd rule, only 3rd on
+			true,
+			[]RuleInfo{
+				{&OffRule{}, RuleOff, RuleContinue},
+				{&OffRule{}, RuleOn, RuleContinue},
+				{&OnRule{}, RuleOn, RuleOff},
+			},
+			true,
+		},
+		{
+			"test cascade to last rule (continue to last rule)",
+			// must match either 2nd or 3rd, all 3 off
+			true,
+			[]RuleInfo{
+				{&OffRule{}, RuleOff, RuleContinue},
+				{&OffRule{}, RuleOn, RuleContinue},
+				{&OffRule{}, RuleOn, RuleOff},
+			},
+			false,
+		},
+		{
+			"test default behavior is off if all rules are continue",
+			true,
+			[]RuleInfo{
+				{&OffRule{}, RuleOn, RuleContinue},
+				{&OffRule{}, RuleOn, RuleOff},
+				{&OnRule{}, RuleContinue, RuleOff},
+			},
+			false,
+		},
+		{
+			"test default on if no rules and active = true",
+			true,
+			[]RuleInfo{},
+			true,
+		},
+		{
+			"test return false categorically if active = false",
+			false,
+			[]RuleInfo{
+				{&OnRule{}, RuleOn, RuleOn},
+			},
+			false,
 		},
 	}
-	return []Flag{testFlag}, time.Time{}, nil
-}
 
-func TestDefaultTags(t *testing.T) {
-	t.Parallel()
-
-	const iterations = 100000
-	g, buf := testGoforit(DefaultInterval, &dummyDefaultFlagsBackend{}, enabledTickerInterval)
-	defer g.Close()
-
-	// if no properties passed, and no default tags added, then should return false
-	assert.False(t, g.Enabled(context.Background(), "test", nil))
-
-	// test match list rule by adding hostname to default tag
-	g.AddDefaultTags(map[string]string{"host_name": "apibox_123", "env": "prod"})
-	assert.True(t, g.Enabled(context.Background(), "test", nil))
-
-	// test overriding global default in local props map
-	assert.False(t, g.Enabled(context.Background(), "test", map[string]string{"host_name": "apibox_789"}))
-
-	// if missing cluster+db, then rate rule should return false
-	assert.False(t, g.Enabled(context.Background(), "test", map[string]string{"host_name": "apibox_001"}))
-
-	// if only one of cluster and db, then rate rule should return false
-	assert.False(t, g.Enabled(context.Background(), "test", map[string]string{"host_name": "apibox_001", "db": "mongo-prod"}))
-
-	// test combination of global tag and local props
-	g.AddDefaultTags(map[string]string{"cluster": "northwest-01"})
-	assert.True(t, g.Enabled(context.Background(), "test", map[string]string{"host_name": "apibox_001", "db": "mongo-prod"}))
-
-	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
-	assert.True(t, len(lines) == 6)
-	for i, line := range lines {
-		if i%2 == 1 {
-			assert.Contains(t, line, "No property")
-			assert.Contains(t, line, "in properties map or default tags")
-		}
+	for _, tc := range testCases {
+		flag := Flag{tc.name, tc.active, tc.rules}
+		enabled, err := flag.Enabled(map[string]string{})
+		assert.NoError(t, err)
+		assert.Equal(t, tc.expected, enabled, tc.name)
 	}
-}
-
-func TestOverride(t *testing.T) {
-	t.Parallel()
-
-	backend := BackendFromFile(filepath.Join("fixtures", "flags_example.csv"))
-	g, _ := testGoforit(10*time.Millisecond, backend, enabledTickerInterval)
-	defer g.Close()
-	g.RefreshFlags(backend)
-
-	// Empty context gets values from backend.
-	assert.False(t, g.Enabled(context.Background(), "go.sun.money", nil))
-	assert.True(t, g.Enabled(context.Background(), "go.moon.mercury", nil))
-	assert.False(t, g.Enabled(context.Background(), "go.extra", nil))
-
-	// Nil is equivalent to empty context.
-	assert.False(t, g.Enabled(nil, "go.sun.money", nil))
-	assert.True(t, g.Enabled(nil, "go.moon.mercury", nil))
-	assert.False(t, g.Enabled(nil, "go.extra", nil))
-
-	// Can override to true in context.
-	ctx := context.Background()
-	ctx = Override(ctx, "go.sun.money", true)
-	assert.True(t, g.Enabled(ctx, "go.sun.money", nil))
-	assert.True(t, g.Enabled(ctx, "go.moon.mercury", nil))
-	assert.False(t, g.Enabled(ctx, "go.extra", nil))
-
-	// Can override to false.
-	ctx = Override(ctx, "go.moon.mercury", false)
-	assert.True(t, g.Enabled(ctx, "go.sun.money", nil))
-	assert.False(t, g.Enabled(ctx, "go.moon.mercury", nil))
-	assert.False(t, g.Enabled(ctx, "go.extra", nil))
-
-	// Can override brand new flag.
-	ctx = Override(ctx, "go.extra", true)
-	assert.True(t, g.Enabled(ctx, "go.sun.money", nil))
-	assert.False(t, g.Enabled(ctx, "go.moon.mercury", nil))
-	assert.True(t, g.Enabled(ctx, "go.extra", nil))
-
-	// Can override an override.
-	ctx = Override(ctx, "go.extra", false)
-	assert.True(t, g.Enabled(ctx, "go.sun.money", nil))
-	assert.False(t, g.Enabled(ctx, "go.moon.mercury", nil))
-	assert.False(t, g.Enabled(ctx, "go.extra", nil))
-
-	// Separate contexts don't interfere with each other.
-	// This allows parallel tests that use feature flags.
-	ctx2 := Override(context.Background(), "go.extra", true)
-	assert.True(t, g.Enabled(ctx, "go.sun.money", nil))
-	assert.False(t, g.Enabled(ctx, "go.moon.mercury", nil))
-	assert.False(t, g.Enabled(ctx, "go.extra", nil))
-	assert.False(t, g.Enabled(ctx2, "go.sun.money", nil))
-	assert.True(t, g.Enabled(ctx2, "go.moon.mercury", nil))
-	assert.True(t, g.Enabled(ctx2, "go.extra", nil))
-
-	// Overrides apply to child contexts.
-	child := context.WithValue(ctx, "foo", "bar")
-	assert.True(t, g.Enabled(child, "go.sun.money", nil))
-	assert.False(t, g.Enabled(child, "go.moon.mercury", nil))
-	assert.False(t, g.Enabled(child, "go.extra", nil))
-
-	// Changes to child contexts don't affect parents.
-	child = Override(child, "go.moon.mercury", true)
-	assert.True(t, g.Enabled(child, "go.sun.money", nil))
-	assert.True(t, g.Enabled(child, "go.moon.mercury", nil))
-	assert.False(t, g.Enabled(child, "go.extra", nil))
-	assert.True(t, g.Enabled(ctx, "go.sun.money", nil))
-	assert.False(t, g.Enabled(ctx, "go.moon.mercury", nil))
-	assert.False(t, g.Enabled(ctx, "go.extra", nil))
-}
-
-func TestOverrideWithoutInit(t *testing.T) {
-	t.Parallel()
-
-	g, _ := testGoforit(0, nil, enabledTickerInterval)
-
-	// Everything is false by default.
-	assert.False(t, g.Enabled(context.Background(), "go.sun.money", nil))
-	assert.False(t, g.Enabled(context.Background(), "go.moon.mercury", nil))
-
-	// Can override.
-	ctx := Override(context.Background(), "go.sun.money", true)
-	assert.True(t, g.Enabled(ctx, "go.sun.money", nil))
-	assert.False(t, g.Enabled(ctx, "go.moon.mercury", nil))
-}
-
-type dummyAgeBackend struct {
-	t   time.Time
-	mtx sync.RWMutex
-}
-
-func (b *dummyAgeBackend) Refresh() ([]Flag, time.Time, error) {
-	var testFlag = Flag{
-		"go.sun.money",
-		true,
-		[]RuleInfo{},
-	}
-	b.mtx.RLock()
-	defer b.mtx.RUnlock()
-	return []Flag{testFlag}, b.t, nil
-}
-
-// Test to see proper monitoring of age of the flags dump
-func TestCacheFileMetric(t *testing.T) {
-	t.Parallel()
-
-	backend := &dummyAgeBackend{t: time.Now().Add(-10 * time.Minute)}
-	g, _ := testGoforit(10*time.Millisecond, backend, enabledTickerInterval)
-	defer g.Close()
-
-	time.Sleep(50 * time.Millisecond)
-	func() {
-		backend.mtx.Lock()
-		defer backend.mtx.Unlock()
-		backend.t = time.Now()
-	}()
-	time.Sleep(50 * time.Millisecond)
-
-	// We expect something like: [600, 600.01, ..., 0.0, 0.01, ...]
-	last := math.Inf(-1)
-	old := 0
-	recent := 0
-	for _, v := range g.stats.(*mockStatsd).getHistogramValues("goforit.flags.cache_file_age_s") {
-		if v > 300 {
-			// Should be older than last time
-			assert.True(t, v > last)
-			// Should be about 10 minutes
-			assert.InDelta(t, 600, v, 3)
-			old++
-			assert.Zero(t, recent, "Should never go from new -> old")
-		} else {
-			// Should be older (unless we just wrote the file)
-			if recent > 0 {
-				assert.True(t, v > last)
-			}
-			// Should be about zero
-			assert.InDelta(t, 0, v, 3)
-			recent++
-		}
-		last = v
-	}
-	assert.True(t, old > 2)
-	assert.True(t, recent > 2)
-}
-
-// Test to see proper monitoring of refreshing the flags dump file from disc
-func TestRefreshCycleMetric(t *testing.T) {
-	t.Parallel()
-
-	backend := &dummyAgeBackend{t: time.Now().Add(-10 * time.Minute)}
-	g, _ := testGoforit(10*time.Millisecond, backend, time.Second)
-	defer g.Close()
-
-	tickerC := make(chan time.Time, 1)
-	f, _ := g.flags.Load("go.sun.money")
-	flag := f.(flagHolder)
-	flag.enabledTicker = &time.Ticker{C: tickerC}
-	g.flags.Store("go.sun.money", flag)
-
-	iters := 30
-	for i := 0; i < iters; i++ {
-		tickerC <- time.Now()
-		g.Enabled(nil, "go.sun.money", nil)
-		time.Sleep(3 * time.Millisecond)
-	}
-
-	// want to stop ticker to simulate Refresh() hanging
-	g.ticker.Stop()
-	time.Sleep(3 * time.Millisecond)
-
-	for i := 0; i < iters; i++ {
-		tickerC <- time.Now()
-		g.Enabled(nil, "go.sun.money", nil)
-		time.Sleep(3 * time.Millisecond)
-	}
-
-	values := g.stats.(*mockStatsd).getHistogramValues("goforit.flags.last_refresh_s")
-	// We expect something like: [0, 0.01, 0, 0.01, ..., 0, 0.01, 0.02, 0.03]
-	for i := 0; i < iters; i++ {
-		v := values[i]
-		// Should be small. Really 10ms, but add a bit of wiggle room
-		assert.True(t, v < 0.03)
-	}
-
-	last := math.Inf(-1)
-	large := 0
-	for i := iters; i < 2*iters; i++ {
-		v := values[i]
-		assert.True(t, v > last, fmt.Sprintf("%d: %v: %v", i, v, values))
-		last = v
-		if v > 0.03 {
-			// At least some should be large now, since we're not refreshing
-			large++
-		}
-	}
-	assert.True(t, large > 2)
-}
-
-func TestStaleFile(t *testing.T) {
-	t.Parallel()
-
-	backend := &dummyAgeBackend{t: time.Now().Add(-1000 * time.Hour)}
-	g, buf := testGoforit(10*time.Millisecond, backend, enabledTickerInterval)
-	defer g.Close()
-	g.SetStalenessThreshold(10*time.Minute + 42*time.Second)
-
-	time.Sleep(50 * time.Millisecond)
-
-	// Should see staleness warnings for backend
-	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
-	assert.True(t, len(lines) > 2)
-	for _, line := range lines {
-		assert.Contains(t, line, "10m42")
-		assert.Contains(t, line, "Backend")
-	}
-}
-
-func TestNoStaleFile(t *testing.T) {
-	t.Parallel()
-
-	backend := &dummyAgeBackend{t: time.Now().Add(-1000 * time.Hour)}
-	g, buf := testGoforit(10*time.Millisecond, backend, enabledTickerInterval)
-	defer g.Close()
-
-	time.Sleep(50 * time.Millisecond)
-
-	// Never set staleness, so no warnings
-	assert.Zero(t, buf.String())
-}
-
-func TestStaleRefresh(t *testing.T) {
-	t.Parallel()
-
-	backend := &dummyBackend{}
-	g, buf := testGoforit(10*time.Millisecond, backend, time.Nanosecond)
-	g.SetStalenessThreshold(50 * time.Millisecond)
-
-	// Simulate stopping refresh
-	g.ticker.Stop()
-	time.Sleep(100 * time.Millisecond)
-
-	for i := 0; i < 10; i++ {
-		g.Enabled(nil, "go.sun.money", nil)
-	}
-
-	// Should see just one staleness warning
-	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
-	assert.Equal(t, 1, len(lines))
-	assert.Contains(t, lines[0], "Refresh")
-	assert.Contains(t, lines[0], "50ms")
 }

--- a/goforit.go
+++ b/goforit.go
@@ -40,6 +40,7 @@ type Goforit interface {
 }
 
 type printFunc func(msg string, args ...interface{})
+type randFunc func() float64
 
 type goforit struct {
 	ticker *time.Ticker
@@ -221,7 +222,7 @@ func (g *goforit) Enabled(ctx context.Context, name string, properties map[strin
 	}
 
 	var err error
-	enabled, err = flag.flag.Enabled(mergedProperties)
+	enabled, err = flag.flag.Enabled(g.rand, mergedProperties)
 	if err != nil {
 		g.printf(err.Error())
 	}

--- a/goforit.go
+++ b/goforit.go
@@ -1,0 +1,358 @@
+package goforit
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"math/rand"
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/DataDog/datadog-go/statsd"
+)
+
+// The default statsd address to emit metrics to.
+const DefaultStatsdAddr = "127.0.0.1:8200"
+
+const lastAssertInterval = 5 * time.Minute
+
+const enabledTickerInterval = 10 * time.Second
+
+// StatsdClient is the set of methods required to emit metrics to statsd, for
+// customizing behavior or mocking.
+type StatsdClient interface {
+	Histogram(string, float64, []string, float64) error
+	Gauge(string, float64, []string, float64) error
+	Count(string, int64, []string, float64) error
+	SimpleServiceCheck(string, statsd.ServiceCheckStatus) error
+}
+
+// Goforit is the main interface for the library to check if flags enabled, refresh flags
+// customizing behavior or mocking.
+type Goforit interface {
+	Enabled(ctx context.Context, name string, props map[string]string) (enabled bool)
+	RefreshFlags(backend Backend)
+	SetStalenessThreshold(threshold time.Duration)
+	AddDefaultTags(tags map[string]string)
+	Close() error
+}
+
+type printFunc func(msg string, args ...interface{})
+
+type goforit struct {
+	ticker *time.Ticker
+
+	stalenessMtx       sync.RWMutex
+	stalenessThreshold time.Duration
+
+	flags sync.Map
+
+	enabledTickerInterval time.Duration
+	// If a flag doesn't exist, this shared ticker will be used.
+	enabledTicker *time.Ticker
+
+	// Unix time in nanos.
+	lastFlagRefreshTime int64
+
+	defaultTags sync.Map
+
+	stats StatsdClient
+
+	// Last time we alerted that flags may be out of date
+	lastAssertMtx sync.Mutex
+	lastAssert    time.Time
+
+	// rand is not concurrency safe, in general
+	rndMtx sync.Mutex
+	rnd    *rand.Rand
+
+	printf printFunc
+}
+
+const DefaultInterval = 30 * time.Second
+
+func newWithoutInit(enabledTickerInterval time.Duration) *goforit {
+	stats, _ := statsd.New(DefaultStatsdAddr)
+	return &goforit{
+		stats:                 stats,
+		enabledTickerInterval: enabledTickerInterval,
+		enabledTicker:         time.NewTicker(enabledTickerInterval),
+		rnd:                   rand.New(rand.NewSource(time.Now().UnixNano())),
+		printf:                log.New(os.Stderr, "[goforit] ", log.LstdFlags).Printf,
+	}
+}
+
+// New creates a new goforit
+func New(interval time.Duration, backend Backend, opts ...Option) Goforit {
+	g := newWithoutInit(enabledTickerInterval)
+	g.init(interval, backend, opts...)
+	return g
+}
+
+type Option interface {
+	apply(g *goforit)
+}
+
+type optionFunc func(g *goforit)
+
+func (o optionFunc) apply(g *goforit) {
+	o(g)
+}
+
+// Logger uses the supplied function to log errors. By default, errors are
+// written to os.Stderr.
+func Logger(printf func(msg string, args ...interface{})) Option {
+	return optionFunc(func(g *goforit) {
+		g.printf = printf
+	})
+}
+
+// Statsd uses the supplied client to emit metrics to. By default, a client is
+// created and configured to emit metrics to DefaultStatsdAddr.
+func Statsd(stats StatsdClient) Option {
+	return optionFunc(func(g *goforit) {
+		g.stats = stats
+	})
+}
+
+func (g *goforit) rand() float64 {
+	g.rndMtx.Lock()
+	defer g.rndMtx.Unlock()
+	return g.rnd.Float64()
+}
+
+type flagHolder struct {
+	flag          Flag
+	enabledTicker *time.Ticker
+}
+
+func (g *goforit) getStalenessThreshold() time.Duration {
+	g.stalenessMtx.RLock()
+	defer g.stalenessMtx.RUnlock()
+	return g.stalenessThreshold
+}
+
+func (g *goforit) logStaleCheck() bool {
+	g.lastAssertMtx.Lock()
+	defer g.lastAssertMtx.Unlock()
+	if time.Since(g.lastAssert) < lastAssertInterval {
+		return false
+	}
+	g.lastAssert = time.Now()
+	return true
+}
+
+// Check if a time is stale.
+func (g *goforit) staleCheck(t time.Time, metric string, metricRate float64, msg string, checkLastAssert bool) {
+	if t.IsZero() {
+		// Not really useful to treat this as a real time
+		return
+	}
+
+	// Report the staleness
+	staleness := time.Since(t)
+	g.stats.Histogram(metric, staleness.Seconds(), nil, metricRate)
+
+	// Log if we're old
+	thresh := g.getStalenessThreshold()
+	if thresh == 0 {
+		return
+	}
+	if staleness <= thresh {
+		return
+	}
+	// Don't log too often!
+	if !checkLastAssert || g.logStaleCheck() {
+		g.printf(msg, staleness, thresh)
+	}
+}
+
+// Enabled returns a boolean indicating
+// whether or not the flag should be considered
+// enabled. It returns false if no flag with the specified
+// name is found
+func (g *goforit) Enabled(ctx context.Context, name string, properties map[string]string) (enabled bool) {
+	enabled = false
+	f, ok := g.flags.Load(name)
+	var flag flagHolder
+	var tickerC <-chan time.Time
+	if ok {
+		flag = f.(flagHolder)
+		tickerC = flag.enabledTicker.C
+	} else {
+		tickerC = g.enabledTicker.C
+	}
+
+	select {
+	case <-tickerC:
+		defer func() {
+			var gauge float64
+			if enabled {
+				gauge = 1
+			}
+			g.stats.Gauge("goforit.flags.enabled", gauge, []string{fmt.Sprintf("flag:%s", name)}, 1)
+			last := atomic.LoadInt64(&g.lastFlagRefreshTime)
+			// time.Duration is conveniently measured in nanoseconds.
+			lastRefreshTime := time.Unix(last/int64(time.Second), last%int64(time.Second))
+			g.staleCheck(lastRefreshTime, "goforit.flags.last_refresh_s", 1,
+				"Refresh cycle has not run in %s, past our threshold (%s)", true)
+		}()
+	default:
+	}
+
+	// Check for an override.
+	if ctx != nil {
+		if ov, ok := ctx.Value(overrideContextKey).(overrides); ok {
+			if enabled, ok = ov[name]; ok {
+				return
+			}
+		}
+	}
+
+	mergedProperties := make(map[string]string)
+	g.defaultTags.Range(func(k, v interface{}) bool {
+		mergedProperties[k.(string)] = v.(string)
+		return true
+	})
+	for k, v := range properties {
+		mergedProperties[k] = v
+	}
+
+	var err error
+	enabled, err = flag.flag.Enabled(mergedProperties)
+	if err != nil {
+		g.printf(err.Error())
+	}
+	return
+}
+
+// RefreshFlags will use the provided thunk function to
+// fetch all feature flags and update the internal cache.
+// The thunk provided can use a variety of mechanisms for
+// querying the flag values, such as a local file or
+// Consul key/value storage.
+func (g *goforit) RefreshFlags(backend Backend) {
+	// Ask the backend for the flags
+	var checkStatus statsd.ServiceCheckStatus
+	defer func() {
+		g.stats.SimpleServiceCheck("goforit.refreshFlags.present", checkStatus)
+	}()
+	refreshedFlags, updated, err := backend.Refresh()
+	if err != nil {
+		checkStatus = statsd.Warn
+		g.stats.Count("goforit.refreshFlags.errors", 1, nil, 1)
+		g.printf("Error refreshing flags: %s", err)
+		return
+	}
+	atomic.StoreInt64(&g.lastFlagRefreshTime, time.Now().UnixNano())
+
+	deleted := make(map[string]bool)
+	g.flags.Range(func(name, flag interface{}) bool {
+		deleted[name.(string)] = true
+		return true
+	})
+
+	for _, flag := range refreshedFlags {
+		delete(deleted, flag.Name)
+		oldFlag, ok := g.flags.Load(flag.Name)
+		if ok {
+			// Avoid churning the map if the flag hasn't changed.
+			oldHolder := oldFlag.(flagHolder)
+			if !oldHolder.flag.Equal(flag) {
+				holder := flagHolder{flag: flag, enabledTicker: oldHolder.enabledTicker}
+				g.flags.Store(flag.Name, holder)
+			}
+		} else {
+			holder := flagHolder{flag: flag, enabledTicker: time.NewTicker(g.enabledTickerInterval)}
+			g.flags.Store(flag.Name, holder)
+		}
+	}
+
+	for name := range deleted {
+		f, ok := g.flags.Load(name)
+		if ok {
+			f.(flagHolder).enabledTicker.Stop()
+			g.flags.Delete(name)
+		}
+	}
+
+	g.staleCheck(updated, "goforit.flags.cache_file_age_s", 0.1,
+		"Backend is stale (%s) past our threshold (%s)", false)
+
+	return
+}
+
+func (g *goforit) SetStalenessThreshold(threshold time.Duration) {
+	g.stalenessMtx.Lock()
+	defer g.stalenessMtx.Unlock()
+	g.stalenessThreshold = threshold
+}
+
+func (g *goforit) AddDefaultTags(tags map[string]string) {
+	for k, v := range tags {
+		g.defaultTags.Store(k, v)
+	}
+}
+
+// init initializes the flag backend, using the provided refresh function
+// to update the internal cache of flags periodically, at the specified interval.
+// Applies passed initialization options to the goforit instance.
+func (g *goforit) init(interval time.Duration, backend Backend, opts ...Option) {
+	for _, opt := range opts {
+		opt.apply(g)
+	}
+
+	g.RefreshFlags(backend)
+	if interval != 0 {
+		ticker := time.NewTicker(interval)
+		g.ticker = ticker
+
+		go func() {
+			for range ticker.C {
+				g.RefreshFlags(backend)
+			}
+		}()
+	}
+}
+
+// A unique context key for overrides
+type overrideContextKeyType struct{}
+
+var overrideContextKey = overrideContextKeyType{}
+
+type overrides map[string]bool
+
+// Override allows overriding the value of a goforit flag within a context.
+// This is mainly useful for tests.
+func Override(ctx context.Context, name string, value bool) context.Context {
+	ov := overrides{}
+	if old, ok := ctx.Value(overrideContextKey).(overrides); ok {
+		for k, v := range old {
+			ov[k] = v
+		}
+	}
+	ov[name] = value
+	return context.WithValue(ctx, overrideContextKey, ov)
+}
+
+// Close releases resources held
+// It's still safe to call Enabled()
+func (g *goforit) Close() error {
+	if g.ticker != nil {
+		g.ticker.Stop()
+		g.ticker = nil
+
+		g.flags.Range(func(k, v interface{}) bool {
+			v.(flagHolder).enabledTicker.Stop()
+			return true
+		})
+
+		g.enabledTicker.Stop()
+	}
+	return nil
+}
+
+// for the interface compatability static check
+var _ Goforit = &goforit{}

--- a/goforit_test.go
+++ b/goforit_test.go
@@ -1,0 +1,557 @@
+package goforit
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log"
+	"math"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-go/statsd"
+	"github.com/stretchr/testify/assert"
+)
+
+// arbitrary but fixed for reproducible testing
+const seed = 5194304667978865136
+
+const ε = .02
+
+type mockStatsd struct {
+	lock            sync.RWMutex
+	histogramValues map[string][]float64
+}
+
+func (m *mockStatsd) Gauge(string, float64, []string, float64) error {
+	return nil
+}
+
+func (m *mockStatsd) Count(string, int64, []string, float64) error {
+	return nil
+}
+
+func (m *mockStatsd) SimpleServiceCheck(string, statsd.ServiceCheckStatus) error {
+	return nil
+}
+
+func (m *mockStatsd) Histogram(name string, value float64, tags []string, rate float64) error {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	if m.histogramValues == nil {
+		m.histogramValues = make(map[string][]float64)
+	}
+	m.histogramValues[name] = append(m.histogramValues[name], value)
+	return nil
+}
+
+func (m *mockStatsd) getHistogramValues(name string) []float64 {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	s := make([]float64, len(m.histogramValues[name]))
+	copy(s, m.histogramValues[name])
+	return s
+}
+
+var _ StatsdClient = &mockStatsd{}
+
+// Build a goforit for testing
+// Also return the log output
+func testGoforit(interval time.Duration, backend Backend, enabledTickerInterval time.Duration, options ...Option) (*goforit, *bytes.Buffer) {
+	g := newWithoutInit(enabledTickerInterval)
+	g.rnd = rand.New(rand.NewSource(seed))
+	var buf bytes.Buffer
+	g.printf = log.New(&buf, "", 9).Printf
+	g.stats = &mockStatsd{}
+
+	if backend != nil {
+		g.init(interval, backend, options...)
+	}
+
+	return g, &buf
+}
+
+func TestGlobal(t *testing.T) {
+	// Not parallel, testing global behavior
+	backend := BackendFromFile(filepath.Join("fixtures", "flags_example.csv"))
+	globalGoforit.stats = &mockStatsd{} // prevent logging real metrics
+
+	Init(DefaultInterval, backend)
+	defer Close()
+
+	assert.False(t, Enabled(nil, "go.sun.money", nil))
+	assert.True(t, Enabled(nil, "go.moon.mercury", nil))
+}
+
+func TestGlobalInitOptions(t *testing.T) {
+	// Not parallel, testing global behavior
+	backend := BackendFromFile(filepath.Join("fixtures", "flags_example.csv"))
+	stats := &mockStatsd{}
+	Init(DefaultInterval, backend, Statsd(stats))
+	defer Close()
+
+	assert.Equal(t, stats, globalGoforit.stats)
+}
+
+func TestEnabled(t *testing.T) {
+	t.Parallel()
+
+	const iterations = 100000
+
+	backend := BackendFromFile(filepath.Join("fixtures", "flags_example.csv"))
+	g, _ := testGoforit(DefaultInterval, backend, enabledTickerInterval)
+	defer g.Close()
+
+	assert.False(t, g.Enabled(context.Background(), "go.sun.money", nil))
+	assert.True(t, g.Enabled(context.Background(), "go.moon.mercury", nil))
+
+	// nil is equivalent to empty context
+	assert.False(t, g.Enabled(nil, "go.sun.money", nil))
+	assert.True(t, g.Enabled(nil, "go.moon.mercury", nil))
+
+	count := 0
+	for i := 0; i < iterations; i++ {
+		if g.Enabled(context.Background(), "go.stars.money", nil) {
+			count++
+		}
+	}
+	actualRate := float64(count) / float64(iterations)
+
+	assert.InEpsilon(t, 0.5, actualRate, ε)
+}
+
+type OnRule struct{}
+type OffRule struct{}
+
+func (r *OnRule) Handle(flag string, props map[string]string) (bool, error) {
+	return true, nil
+}
+
+func (r *OffRule) Handle(flag string, props map[string]string) (bool, error) {
+	return false, nil
+}
+
+// dummyBackend lets us test the RefreshFlags
+// by returning the flags only the second time the Refresh
+// method is called
+type dummyBackend struct {
+	// tally how many times Refresh() has been called
+	refreshedCount int
+}
+
+func (b *dummyBackend) Refresh() ([]Flag, time.Time, error) {
+	defer func() {
+		b.refreshedCount++
+	}()
+
+	if b.refreshedCount == 0 {
+		return []Flag{}, time.Time{}, nil
+	}
+
+	f, err := os.Open(filepath.Join("fixtures", "flags_example.csv"))
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+	defer f.Close()
+	return parseFlagsCSV(f)
+}
+
+func TestRefresh(t *testing.T) {
+	t.Parallel()
+
+	backend := &dummyBackend{}
+	g, _ := testGoforit(10*time.Millisecond, backend, enabledTickerInterval)
+
+	assert.False(t, g.Enabled(context.Background(), "go.sun.money", nil))
+	assert.False(t, g.Enabled(context.Background(), "go.moon.mercury", nil))
+
+	defer g.Close()
+
+	// ensure refresh runs twice to avoid race conditions
+	// in which the Refresh method returns but the assertions get called
+	// before the flags are actually updated
+	for backend.refreshedCount < 2 {
+		<-time.After(10 * time.Millisecond)
+	}
+
+	assert.False(t, g.Enabled(context.Background(), "go.sun.money", nil))
+	assert.True(t, g.Enabled(context.Background(), "go.moon.mercury", nil))
+}
+
+func TestRefreshTicker(t *testing.T) {
+	t.Parallel()
+
+	backend := BackendFromFile(filepath.Join("fixtures", "flags_example.csv"))
+	g, _ := testGoforit(10*time.Second, backend, enabledTickerInterval)
+	defer g.Close()
+
+	earthTicker := time.NewTicker(time.Nanosecond)
+	g.flags.Store("go.earth.money", flagHolder{Flag{"go.earth.money", true, nil}, earthTicker})
+	f, ok := g.flags.Load("go.moon.mercury")
+	assert.True(t, ok)
+	moonTicker := f.(flagHolder).enabledTicker
+	g.flags.Delete("go.stars.money")
+	// Give tickers time to run.
+	time.Sleep(time.Millisecond)
+
+	g.RefreshFlags(backend)
+
+	_, ok = g.flags.Load("go.sun.money")
+	assert.True(t, ok)
+	_, ok = g.flags.Load("go.moon.mercury")
+	assert.True(t, ok)
+	_, ok = g.flags.Load("go.stars.money")
+	assert.True(t, ok)
+	_, ok = g.flags.Load("go.earth.money")
+	assert.False(t, ok)
+
+	// Make sure that the ticker was preserved.
+	f, ok = g.flags.Load("go.moon.mercury")
+	assert.True(t, ok)
+	assert.Equal(t, moonTicker, f.(flagHolder).enabledTicker)
+
+	// Make sure that the deleted flag's ticker was stopped.
+	_, ok = <-earthTicker.C
+	assert.True(t, ok)
+	// If the ticker wasn't deleted, make sure it can run again.
+	time.Sleep(time.Millisecond)
+	select {
+	case _, ok = <-earthTicker.C:
+		// If the ticker was stopped, there's no way we'd get a 2nd tick.
+		assert.False(t, ok)
+	default:
+	}
+}
+
+// BenchmarkEnabled50 runs a benchmark for a feature flag
+// that is enabled for 50% of operations.
+func BenchmarkEnabled50(b *testing.B) {
+	backend := BackendFromFile(filepath.Join("fixtures", "flags_example.csv"))
+	g, _ := testGoforit(10*time.Millisecond, backend, enabledTickerInterval)
+	defer g.Close()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = g.Enabled(context.Background(), "go.stars.money", nil)
+	}
+}
+
+// BenchmarkEnabled100 runs a benchmark for a feature flag
+// that is enabled for 100% of operations.
+func BenchmarkEnabled100(b *testing.B) {
+	backend := BackendFromFile(filepath.Join("fixtures", "flags_example.csv"))
+	g, _ := testGoforit(10*time.Millisecond, backend, enabledTickerInterval)
+	defer g.Close()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = g.Enabled(context.Background(), "go.moon.mercury", nil)
+	}
+}
+
+type dummyDefaultFlagsBackend struct{}
+
+func (b *dummyDefaultFlagsBackend) Refresh() ([]Flag, time.Time, error) {
+	var testFlag = Flag{
+		"test",
+		true,
+		[]RuleInfo{
+			{&MatchListRule{"host_name", []string{"apibox_789"}}, RuleOff, RuleContinue},
+			{&MatchListRule{"host_name", []string{"apibox_123", "apibox_456"}}, RuleOn, RuleContinue},
+			{&RateRule{1, []string{"cluster", "db"}}, RuleOn, RuleOff},
+		},
+	}
+	return []Flag{testFlag}, time.Time{}, nil
+}
+
+func TestDefaultTags(t *testing.T) {
+	t.Parallel()
+
+	const iterations = 100000
+	g, buf := testGoforit(DefaultInterval, &dummyDefaultFlagsBackend{}, enabledTickerInterval)
+	defer g.Close()
+
+	// if no properties passed, and no default tags added, then should return false
+	assert.False(t, g.Enabled(context.Background(), "test", nil))
+
+	// test match list rule by adding hostname to default tag
+	g.AddDefaultTags(map[string]string{"host_name": "apibox_123", "env": "prod"})
+	assert.True(t, g.Enabled(context.Background(), "test", nil))
+
+	// test overriding global default in local props map
+	assert.False(t, g.Enabled(context.Background(), "test", map[string]string{"host_name": "apibox_789"}))
+
+	// if missing cluster+db, then rate rule should return false
+	assert.False(t, g.Enabled(context.Background(), "test", map[string]string{"host_name": "apibox_001"}))
+
+	// if only one of cluster and db, then rate rule should return false
+	assert.False(t, g.Enabled(context.Background(), "test", map[string]string{"host_name": "apibox_001", "db": "mongo-prod"}))
+
+	// test combination of global tag and local props
+	g.AddDefaultTags(map[string]string{"cluster": "northwest-01"})
+	assert.True(t, g.Enabled(context.Background(), "test", map[string]string{"host_name": "apibox_001", "db": "mongo-prod"}))
+
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	assert.True(t, len(lines) == 6)
+	for i, line := range lines {
+		if i%2 == 1 {
+			assert.Contains(t, line, "No property")
+			assert.Contains(t, line, "in properties map or default tags")
+		}
+	}
+}
+
+func TestOverride(t *testing.T) {
+	t.Parallel()
+
+	backend := BackendFromFile(filepath.Join("fixtures", "flags_example.csv"))
+	g, _ := testGoforit(10*time.Millisecond, backend, enabledTickerInterval)
+	defer g.Close()
+	g.RefreshFlags(backend)
+
+	// Empty context gets values from backend.
+	assert.False(t, g.Enabled(context.Background(), "go.sun.money", nil))
+	assert.True(t, g.Enabled(context.Background(), "go.moon.mercury", nil))
+	assert.False(t, g.Enabled(context.Background(), "go.extra", nil))
+
+	// Nil is equivalent to empty context.
+	assert.False(t, g.Enabled(nil, "go.sun.money", nil))
+	assert.True(t, g.Enabled(nil, "go.moon.mercury", nil))
+	assert.False(t, g.Enabled(nil, "go.extra", nil))
+
+	// Can override to true in context.
+	ctx := context.Background()
+	ctx = Override(ctx, "go.sun.money", true)
+	assert.True(t, g.Enabled(ctx, "go.sun.money", nil))
+	assert.True(t, g.Enabled(ctx, "go.moon.mercury", nil))
+	assert.False(t, g.Enabled(ctx, "go.extra", nil))
+
+	// Can override to false.
+	ctx = Override(ctx, "go.moon.mercury", false)
+	assert.True(t, g.Enabled(ctx, "go.sun.money", nil))
+	assert.False(t, g.Enabled(ctx, "go.moon.mercury", nil))
+	assert.False(t, g.Enabled(ctx, "go.extra", nil))
+
+	// Can override brand new flag.
+	ctx = Override(ctx, "go.extra", true)
+	assert.True(t, g.Enabled(ctx, "go.sun.money", nil))
+	assert.False(t, g.Enabled(ctx, "go.moon.mercury", nil))
+	assert.True(t, g.Enabled(ctx, "go.extra", nil))
+
+	// Can override an override.
+	ctx = Override(ctx, "go.extra", false)
+	assert.True(t, g.Enabled(ctx, "go.sun.money", nil))
+	assert.False(t, g.Enabled(ctx, "go.moon.mercury", nil))
+	assert.False(t, g.Enabled(ctx, "go.extra", nil))
+
+	// Separate contexts don't interfere with each other.
+	// This allows parallel tests that use feature flags.
+	ctx2 := Override(context.Background(), "go.extra", true)
+	assert.True(t, g.Enabled(ctx, "go.sun.money", nil))
+	assert.False(t, g.Enabled(ctx, "go.moon.mercury", nil))
+	assert.False(t, g.Enabled(ctx, "go.extra", nil))
+	assert.False(t, g.Enabled(ctx2, "go.sun.money", nil))
+	assert.True(t, g.Enabled(ctx2, "go.moon.mercury", nil))
+	assert.True(t, g.Enabled(ctx2, "go.extra", nil))
+
+	// Overrides apply to child contexts.
+	child := context.WithValue(ctx, "foo", "bar")
+	assert.True(t, g.Enabled(child, "go.sun.money", nil))
+	assert.False(t, g.Enabled(child, "go.moon.mercury", nil))
+	assert.False(t, g.Enabled(child, "go.extra", nil))
+
+	// Changes to child contexts don't affect parents.
+	child = Override(child, "go.moon.mercury", true)
+	assert.True(t, g.Enabled(child, "go.sun.money", nil))
+	assert.True(t, g.Enabled(child, "go.moon.mercury", nil))
+	assert.False(t, g.Enabled(child, "go.extra", nil))
+	assert.True(t, g.Enabled(ctx, "go.sun.money", nil))
+	assert.False(t, g.Enabled(ctx, "go.moon.mercury", nil))
+	assert.False(t, g.Enabled(ctx, "go.extra", nil))
+}
+
+func TestOverrideWithoutInit(t *testing.T) {
+	t.Parallel()
+
+	g, _ := testGoforit(0, nil, enabledTickerInterval)
+
+	// Everything is false by default.
+	assert.False(t, g.Enabled(context.Background(), "go.sun.money", nil))
+	assert.False(t, g.Enabled(context.Background(), "go.moon.mercury", nil))
+
+	// Can override.
+	ctx := Override(context.Background(), "go.sun.money", true)
+	assert.True(t, g.Enabled(ctx, "go.sun.money", nil))
+	assert.False(t, g.Enabled(ctx, "go.moon.mercury", nil))
+}
+
+type dummyAgeBackend struct {
+	t   time.Time
+	mtx sync.RWMutex
+}
+
+func (b *dummyAgeBackend) Refresh() ([]Flag, time.Time, error) {
+	var testFlag = Flag{
+		"go.sun.money",
+		true,
+		[]RuleInfo{},
+	}
+	b.mtx.RLock()
+	defer b.mtx.RUnlock()
+	return []Flag{testFlag}, b.t, nil
+}
+
+// Test to see proper monitoring of age of the flags dump
+func TestCacheFileMetric(t *testing.T) {
+	t.Parallel()
+
+	backend := &dummyAgeBackend{t: time.Now().Add(-10 * time.Minute)}
+	g, _ := testGoforit(10*time.Millisecond, backend, enabledTickerInterval)
+	defer g.Close()
+
+	time.Sleep(50 * time.Millisecond)
+	func() {
+		backend.mtx.Lock()
+		defer backend.mtx.Unlock()
+		backend.t = time.Now()
+	}()
+	time.Sleep(50 * time.Millisecond)
+
+	// We expect something like: [600, 600.01, ..., 0.0, 0.01, ...]
+	last := math.Inf(-1)
+	old := 0
+	recent := 0
+	for _, v := range g.stats.(*mockStatsd).getHistogramValues("goforit.flags.cache_file_age_s") {
+		if v > 300 {
+			// Should be older than last time
+			assert.True(t, v > last)
+			// Should be about 10 minutes
+			assert.InDelta(t, 600, v, 3)
+			old++
+			assert.Zero(t, recent, "Should never go from new -> old")
+		} else {
+			// Should be older (unless we just wrote the file)
+			if recent > 0 {
+				assert.True(t, v > last)
+			}
+			// Should be about zero
+			assert.InDelta(t, 0, v, 3)
+			recent++
+		}
+		last = v
+	}
+	assert.True(t, old > 2)
+	assert.True(t, recent > 2)
+}
+
+// Test to see proper monitoring of refreshing the flags dump file from disc
+func TestRefreshCycleMetric(t *testing.T) {
+	t.Parallel()
+
+	backend := &dummyAgeBackend{t: time.Now().Add(-10 * time.Minute)}
+	g, _ := testGoforit(10*time.Millisecond, backend, time.Second)
+	defer g.Close()
+
+	tickerC := make(chan time.Time, 1)
+	f, _ := g.flags.Load("go.sun.money")
+	flag := f.(flagHolder)
+	flag.enabledTicker = &time.Ticker{C: tickerC}
+	g.flags.Store("go.sun.money", flag)
+
+	iters := 30
+	for i := 0; i < iters; i++ {
+		tickerC <- time.Now()
+		g.Enabled(nil, "go.sun.money", nil)
+		time.Sleep(3 * time.Millisecond)
+	}
+
+	// want to stop ticker to simulate Refresh() hanging
+	g.ticker.Stop()
+	time.Sleep(3 * time.Millisecond)
+
+	for i := 0; i < iters; i++ {
+		tickerC <- time.Now()
+		g.Enabled(nil, "go.sun.money", nil)
+		time.Sleep(3 * time.Millisecond)
+	}
+
+	values := g.stats.(*mockStatsd).getHistogramValues("goforit.flags.last_refresh_s")
+	// We expect something like: [0, 0.01, 0, 0.01, ..., 0, 0.01, 0.02, 0.03]
+	for i := 0; i < iters; i++ {
+		v := values[i]
+		// Should be small. Really 10ms, but add a bit of wiggle room
+		assert.True(t, v < 0.03)
+	}
+
+	last := math.Inf(-1)
+	large := 0
+	for i := iters; i < 2*iters; i++ {
+		v := values[i]
+		assert.True(t, v > last, fmt.Sprintf("%d: %v: %v", i, v, values))
+		last = v
+		if v > 0.03 {
+			// At least some should be large now, since we're not refreshing
+			large++
+		}
+	}
+	assert.True(t, large > 2)
+}
+
+func TestStaleFile(t *testing.T) {
+	t.Parallel()
+
+	backend := &dummyAgeBackend{t: time.Now().Add(-1000 * time.Hour)}
+	g, buf := testGoforit(10*time.Millisecond, backend, enabledTickerInterval)
+	defer g.Close()
+	g.SetStalenessThreshold(10*time.Minute + 42*time.Second)
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Should see staleness warnings for backend
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	assert.True(t, len(lines) > 2)
+	for _, line := range lines {
+		assert.Contains(t, line, "10m42")
+		assert.Contains(t, line, "Backend")
+	}
+}
+
+func TestNoStaleFile(t *testing.T) {
+	t.Parallel()
+
+	backend := &dummyAgeBackend{t: time.Now().Add(-1000 * time.Hour)}
+	g, buf := testGoforit(10*time.Millisecond, backend, enabledTickerInterval)
+	defer g.Close()
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Never set staleness, so no warnings
+	assert.Zero(t, buf.String())
+}
+
+func TestStaleRefresh(t *testing.T) {
+	t.Parallel()
+
+	backend := &dummyBackend{}
+	g, buf := testGoforit(10*time.Millisecond, backend, time.Nanosecond)
+	g.SetStalenessThreshold(50 * time.Millisecond)
+
+	// Simulate stopping refresh
+	g.ticker.Stop()
+	time.Sleep(100 * time.Millisecond)
+
+	for i := 0; i < 10; i++ {
+		g.Enabled(nil, "go.sun.money", nil)
+	}
+
+	// Should see just one staleness warning
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	assert.Equal(t, 1, len(lines))
+	assert.Contains(t, lines[0], "Refresh")
+	assert.Contains(t, lines[0], "50ms")
+}

--- a/goforit_test.go
+++ b/goforit_test.go
@@ -191,7 +191,7 @@ func TestRefreshTicker(t *testing.T) {
 	defer g.Close()
 
 	earthTicker := time.NewTicker(time.Nanosecond)
-	g.flags.Store("go.earth.money", flagHolder{Flag{"go.earth.money", true, nil}, earthTicker})
+	g.flags.Store("go.earth.money", flagHolder{Flag1{"go.earth.money", true, nil}, earthTicker})
 	f, ok := g.flags.Load("go.moon.mercury")
 	assert.True(t, ok)
 	moonTicker := f.(flagHolder).enabledTicker
@@ -257,7 +257,7 @@ func BenchmarkEnabled100(b *testing.B) {
 type dummyDefaultFlagsBackend struct{}
 
 func (b *dummyDefaultFlagsBackend) Refresh() ([]Flag, time.Time, error) {
-	var testFlag = Flag{
+	var testFlag = Flag1{
 		"test",
 		true,
 		[]RuleInfo{
@@ -396,7 +396,7 @@ type dummyAgeBackend struct {
 }
 
 func (b *dummyAgeBackend) Refresh() ([]Flag, time.Time, error) {
-	var testFlag = Flag{
+	var testFlag = Flag1{
 		"go.sun.money",
 		true,
 		[]RuleInfo{},

--- a/goforit_test.go
+++ b/goforit_test.go
@@ -191,7 +191,7 @@ func TestRefreshTicker(t *testing.T) {
 	defer g.Close()
 
 	earthTicker := time.NewTicker(time.Nanosecond)
-	g.flags.Store("go.earth.money", flagHolder{Flag1{"go.earth.money", true, nil}, earthTicker})
+	g.flags.Store("go.earth.money", flagHolder{Flag1{"go.earth.money", true, nil}, FlagMayVary, earthTicker})
 	f, ok := g.flags.Load("go.moon.mercury")
 	assert.True(t, ok)
 	moonTicker := f.(flagHolder).enabledTicker

--- a/goforit_test.go
+++ b/goforit_test.go
@@ -128,11 +128,11 @@ func TestEnabled(t *testing.T) {
 type OnRule struct{}
 type OffRule struct{}
 
-func (r *OnRule) Handle(flag string, props map[string]string) (bool, error) {
+func (r *OnRule) Handle(rnd randFunc, flag string, props map[string]string) (bool, error) {
 	return true, nil
 }
 
-func (r *OffRule) Handle(flag string, props map[string]string) (bool, error) {
+func (r *OffRule) Handle(rnd randFunc, flag string, props map[string]string) (bool, error) {
 	return false, nil
 }
 


### PR DESCRIPTION
r? @bartle-stripe 

Support a newer flags format, as used in some other Stripe projects.

* Split out flag-evaluation vs core-library tests
* Make `Flag` an interface, so we can support more formats
* Add the new FFv2 format
    * Run against the pre-existing acceptance tests for FFv2
* Benchmark both old and new flag formats
* Add a new `Flag.Clamp()` method, to optimize handling flags that are always true or false. This keeps our benchmark numbers similar despite the new abstractions
* Document the different flatfile backends
* Update the version of Go everywhere