### PR TITLE
remove reading updated timestamp from v1 JSON featureflag file

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -114,7 +114,16 @@ func readFile(file string, backend string, parse func(io.Reader) ([]Flag, time.T
 }
 
 func (b jsonFileBackend) Refresh() ([]Flag, time.Time, error) {
-	return readFile(b.filename, "json", parseFlagsJSON)
+	flags, updated, err := readFile(b.filename, "json", parseFlagsJSON)
+	if updated != time.Unix(0, 0) {
+		return flags, updated, err
+	}
+
+	fileInfo, err := os.Stat(b.filename)
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+	return flags, fileInfo.ModTime(), nil
 }
 
 func (b csvFileBackend) Refresh() ([]Flag, time.Time, error) {

--- a/fixtures/flags_example_no_timestamp.json
+++ b/fixtures/flags_example_no_timestamp.json
@@ -1,0 +1,40 @@
+{
+  "flags": [
+    {
+      "name": "go.sun.moon",
+      "active": true,
+      "rules": [
+        {
+          "type": "match_list",
+          "property": "host_name",
+          "values": [
+            "apibox_123",
+            "apibox_456"
+          ],
+          "on_match": "off",
+          "on_miss": "continue"
+        },
+        {
+          "type": "match_list",
+          "property": "host_name",
+          "values": [
+            "apibox_789"
+          ],
+          "on_match": "on",
+          "on_miss": "continue"
+        },
+        {
+          "type": "sample",
+          "rate": 0.01,
+          "properties": ["cluster", "db"],
+          "on_match": "on",
+          "on_miss": "off"
+        }
+      ]
+    },
+    {
+      "name": "go.sun.mercury",
+      "rate": 0.5
+    }
+  ]
+}

--- a/flags_test.go
+++ b/flags_test.go
@@ -2,6 +2,8 @@ package goforit
 
 import (
 	"math/rand"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -253,4 +255,23 @@ func TestCascadingRules(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, tc.expected, enabled, tc.name)
 	}
+}
+
+func TestTimestampFallback(t *testing.T) {
+	backend := jsonFileBackend{
+		filename: filepath.Join("fixtures", "flags_example.json"),
+	}
+	_, updated, err := backend.Refresh()
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1519247256), updated.Unix())
+
+	backendNoTimestamp := jsonFileBackend{
+		filename: filepath.Join("fixtures", "flags_example_no_timestamp.json"),
+	}
+	_, updated, err = backendNoTimestamp.Refresh()
+	assert.NoError(t, err)
+
+	info, err := os.Stat(filepath.Join("fixtures", "flags_example_no_timestamp.json"))
+	assert.NoError(t, err)
+	assert.Equal(t, info.ModTime(), updated)
 }


### PR DESCRIPTION
This is to remove the consumption of 'updated' timestamp from JSON featureflags.
Instead, it is now using the file modified time to keep its contract.

The motivation is to remove the timestamp when publishing the featureflag data from mainland, because it's unnecessarily changing the hash of the file.

