### PR TITLE
Add a callback for identifying "deleted" flags

### DIFF
--- a/flags2.go
+++ b/flags2.go
@@ -38,9 +38,16 @@ type Rule2 struct {
 	Predicates []Predicate2
 }
 type Flag2 struct {
-	Name  string
-	Seed  string
-	Rules []Rule2
+	Name    string
+	Seed    string
+	Rules   []Rule2
+	Deleted bool
+}
+
+// DeletableFlag can report whether this flag is scheduled for deletion
+type deletableFlag interface {
+	// IsDeleted yields true if this flag is scheduled for deletion
+	isDeleted() bool
 }
 
 type JSONFormat2 struct {
@@ -144,6 +151,10 @@ func (f Flag2) Equal(other Flag) bool {
 		}
 	}
 	return true
+}
+
+func (f Flag2) isDeleted() bool {
+	return f.Deleted
 }
 
 func (p Predicate2) matches(properties map[string]string) (bool, error) {

--- a/goforit_test.go
+++ b/goforit_test.go
@@ -560,3 +560,27 @@ func TestStaleRefresh(t *testing.T) {
 	assert.Contains(t, lines[0], "Refresh")
 	assert.Contains(t, lines[0], "50ms")
 }
+
+type flagStatus struct {
+	flag   string
+	active bool
+}
+
+func TestEvaluationCallback(t *testing.T) {
+	t.Parallel()
+
+	evaluated := map[flagStatus]int{}
+	backend := BackendFromFile(filepath.Join("fixtures", "flags_example.csv"))
+	g := New(enabledTickerInterval, backend, EvaluationCallback(func(flag string, active bool) {
+		evaluated[flagStatus{flag, active}] += 1
+	}))
+	defer g.Close()
+
+	g.Enabled(nil, "go.sun.money", nil)
+	g.Enabled(nil, "go.moon.mercury", nil)
+	g.Enabled(nil, "go.moon.mercury", nil)
+
+	assert.Equal(t, 2, len(evaluated))
+	assert.Equal(t, 1, evaluated[flagStatus{"go.sun.money", false}])
+	assert.Equal(t, 2, evaluated[flagStatus{"go.moon.mercury", true}])
+}

--- a/goforit_test.go
+++ b/goforit_test.go
@@ -584,3 +584,22 @@ func TestEvaluationCallback(t *testing.T) {
 	assert.Equal(t, 1, evaluated[flagStatus{"go.sun.money", false}])
 	assert.Equal(t, 2, evaluated[flagStatus{"go.moon.mercury", true}])
 }
+
+func TestDeletionCallback(t *testing.T) {
+	t.Parallel()
+
+	deleted := map[flagStatus]int{}
+	backend := BackendFromJSONFile2(filepath.Join("fixtures", "flags2_acceptance.json"))
+	g := New(enabledTickerInterval, backend, DeletedCallback(func(flag string, active bool) {
+		deleted[flagStatus{flag, active}] += 1
+	}))
+	defer g.Close()
+
+	g.Enabled(nil, "on_flag", nil)
+	g.Enabled(nil, "deleted_on_flag", nil)
+	g.Enabled(nil, "deleted_on_flag", nil)
+	g.Enabled(nil, "explicitly_not_deleted_flag", nil)
+
+	assert.Equal(t, 1, len(deleted))
+	assert.Equal(t, 2, deleted[flagStatus{"deleted_on_flag", true}])
+}


### PR DESCRIPTION
r? @bartle-stripe 

The flag state file (CSV or JSON) needs to be built by some other "upstream" service. When someone gets rid of a flag in the upstream, we don't want to delete it from the state file right away, since that would cause any clients that haven't been deployed to suddenly change their behaviour. So the state files grow over time, and eventually become rather large.

To be able to eventually delete flags from the state file, we need to ensure nobody is still using them. This provides a mechanism where the upstream can mark a flag as "scheduled for deletion". Goforit can then emit a callback to indicate whether it ever encounters such a deleted flag. Once we never see such a flag anymore, it will be safe to really delete from state upstream.

This API is a bit awkward, but I don't see a better way to do it without breaking backwards compat. We probably want to design a v2 one of these days!