### PR TITLE
Add errorable flag refresh method

### DIFF
--- a/global.go
+++ b/global.go
@@ -19,6 +19,10 @@ func RefreshFlags(backend Backend) {
 	globalGoforit.RefreshFlags(backend)
 }
 
+func TryRefreshFlags(backend Backend) error {
+	return globalGoforit.TryRefreshFlags(backend)
+}
+
 func SetStalenessThreshold(threshold time.Duration) {
 	globalGoforit.SetStalenessThreshold(threshold)
 }


### PR DESCRIPTION
Add a `TryRefreshFlags` method that returns an error in the case of backend refresh failure. Allowing callers access to the success/failure state of a refresh enables taking action in cases where explicit confirmation of successful flag loading is required.

This isn't the cleanest way to go about supporting this, but it seems like the least invasive without modifying the current API surface.