### PR TITLE
flags2: use pointer receivers to avoid copying structs all around

### DIFF
--- a/flags2/flags2.go
+++ b/flags2/flags2.go
@@ -88,12 +88,13 @@ func (p *Predicate2) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&raw)
 }
 
-func (f Flag2) FlagName() string {
+func (f *Flag2) FlagName() string {
 	return f.Name
 }
 
-func (f Flag2) Enabled(rnd flags.Rand, properties, defaultTags map[string]string) (bool, error) {
-	for _, rule := range f.Rules {
+func (f *Flag2) Enabled(rnd flags.Rand, properties, defaultTags map[string]string) (bool, error) {
+	for i := range f.Rules {
+		rule := &f.Rules[i]
 		match, err := rule.matches(properties, defaultTags)
 		if err != nil {
 			return false, err
@@ -109,7 +110,7 @@ func (f Flag2) Enabled(rnd flags.Rand, properties, defaultTags map[string]string
 	return false, nil
 }
 
-func (f Flag2) Clamp() clamp.Clamp {
+func (f *Flag2) Clamp() clamp.Clamp {
 	if len(f.Rules) == 0 {
 		return clamp.AlwaysOff
 	}
@@ -123,7 +124,7 @@ func (f Flag2) Clamp() clamp.Clamp {
 	return clamp.MayVary
 }
 
-func (p Predicate2) equal(o Predicate2) bool {
+func (p *Predicate2) equal(o Predicate2) bool {
 	if p.Attribute != o.Attribute || p.Operation != o.Operation || len(p.Values) != len(o.Values) {
 		return false
 	}
@@ -137,7 +138,7 @@ func (p Predicate2) equal(o Predicate2) bool {
 	return true
 }
 
-func (r Rule2) equal(o Rule2) bool {
+func (r *Rule2) equal(o Rule2) bool {
 	if r.HashBy != o.HashBy || r.Percent != o.Percent || len(r.Predicates) != len(o.Predicates) {
 		return false
 	}
@@ -149,7 +150,7 @@ func (r Rule2) equal(o Rule2) bool {
 	return true
 }
 
-func (f Flag2) Equal(o *Flag2) bool {
+func (f *Flag2) Equal(o *Flag2) bool {
 	if f.Name != o.Name || f.Seed != o.Seed || len(f.Rules) != len(o.Rules) {
 		return false
 	}
@@ -161,11 +162,11 @@ func (f Flag2) Equal(o *Flag2) bool {
 	return true
 }
 
-func (f Flag2) IsDeleted() bool {
+func (f *Flag2) IsDeleted() bool {
 	return f.Deleted
 }
 
-func (p Predicate2) matches(properties, defaultTags map[string]string) (bool, error) {
+func (p *Predicate2) matches(properties, defaultTags map[string]string) (bool, error) {
 	val, present := properties[p.Attribute]
 	if !present {
 		val, present = defaultTags[p.Attribute]
@@ -184,7 +185,7 @@ func (p Predicate2) matches(properties, defaultTags map[string]string) (bool, er
 	}
 }
 
-func (r Rule2) matches(properties, defaultTags map[string]string) (bool, error) {
+func (r *Rule2) matches(properties, defaultTags map[string]string) (bool, error) {
 	_, hashPresent := properties[r.HashBy]
 	if !hashPresent {
 		_, hashPresent = defaultTags[r.HashBy]
@@ -194,7 +195,8 @@ func (r Rule2) matches(properties, defaultTags map[string]string) (bool, error) 
 		return false, nil
 	}
 
-	for _, pred := range r.Predicates {
+	for i := range r.Predicates {
+		pred := &r.Predicates[i]
 		match, err := pred.matches(properties, defaultTags)
 		if err != nil {
 			return false, err
@@ -207,7 +209,7 @@ func (r Rule2) matches(properties, defaultTags map[string]string) (bool, error) 
 	return true, nil
 }
 
-func (r Rule2) hashValue(seed, val string) float64 {
+func (r *Rule2) hashValue(seed, val string) float64 {
 	h := sha1.New()
 	h.Write([]byte(seed))
 	h.Write([]byte{'.'})
@@ -218,7 +220,7 @@ func (r Rule2) hashValue(seed, val string) float64 {
 	return float64(ival) / float64(1<<16)
 }
 
-func (r Rule2) evaluate(rnd flags.Rand, seed string, properties, defaultTags map[string]string) (bool, error) {
+func (r *Rule2) evaluate(rnd flags.Rand, seed string, properties, defaultTags map[string]string) (bool, error) {
 	if r.Percent >= PercentOn {
 		return true, nil
 	}


### PR DESCRIPTION
Inspired by your PR, it seems like we can improve perf here by using pointer receivers (and explicit reference creation in loops):

```
name                     old time/op    new time/op    delta
GoforitEnabledOn           12.5ns ± 2%    12.2ns ± 1%   -2.75%  (p=0.008 n=5+5)
GoforitEnabledOn-2         34.6ns ± 5%    33.7ns ± 3%     ~     (p=0.421 n=5+5)
GoforitEnabledOn-4         42.3ns ±18%    37.2ns ±12%     ~     (p=0.151 n=5+5)
GoforitEnabledOn-8         61.3ns ± 1%    58.3ns ± 5%   -5.01%  (p=0.008 n=5+5)
GoforitEnabledOff          11.4ns ± 0%    11.5ns ± 0%   +1.21%  (p=0.016 n=4+5)
GoforitEnabledOff-2        38.6ns ±10%    37.0ns ± 6%     ~     (p=0.421 n=5+5)
GoforitEnabledOff-4        46.3ns ±12%    51.9ns ±18%     ~     (p=0.690 n=5+5)
GoforitEnabledOff-8        66.5ns ± 2%    66.2ns ± 0%     ~     (p=0.556 n=5+4)
GoforitEnabledPartial      74.8ns ± 1%    63.6ns ± 0%  -14.97%  (p=0.008 n=5+5)
GoforitEnabledPartial-2    55.0ns ± 5%    48.1ns ± 2%  -12.42%  (p=0.008 n=5+5)
GoforitEnabledPartial-4    52.4ns ±15%    45.1ns ± 3%  -13.89%  (p=0.008 n=5+5)
GoforitEnabledPartial-8    68.2ns ± 2%    68.7ns ± 3%     ~     (p=0.556 n=5+4)
```

The benchmark is in a different repo, and includes testing the wrapper we use.  All tests in this repo, as well as the benchmark pass with the race detector on.