### PR TITLE
make empty+closed *goforit instances `reflect.DeepEqual` for use in unit tests

### DIFF
--- a/fastflags.go
+++ b/fastflags.go
@@ -18,10 +18,7 @@ type flagMap map[string]*flagHolder
 
 // newFastFlags returns a new, empty fastFlags instance.
 func newFastFlags() *fastFlags {
-	ff := new(fastFlags)
-	empty := make(flagMap)
-	ff.flags.Store(&empty)
-	return ff
+	return new(fastFlags)
 }
 
 func (ff *fastFlags) load() flagMap {

--- a/fastflags.go
+++ b/fastflags.go
@@ -9,7 +9,7 @@ import (
 // fastFlags is a structure for fast access to read-mostly feature flags.
 // It supports lockless reads and synchronized updates.
 type fastFlags struct {
-	flags atomic.Value
+	flags atomic.Pointer[flagMap]
 
 	writerLock sync.Mutex
 }
@@ -19,16 +19,20 @@ type flagMap map[string]*flagHolder
 // newFastFlags returns a new, empty fastFlags instance.
 func newFastFlags() *fastFlags {
 	ff := new(fastFlags)
-	ff.flags.Store(make(flagMap))
+	empty := make(flagMap)
+	ff.flags.Store(&empty)
 	return ff
 }
 
 func (ff *fastFlags) load() flagMap {
-	return ff.flags.Load().(flagMap)
+	if flags := ff.flags.Load(); flags != nil {
+		return *flags
+	}
+	return nil
 }
 
 func (ff *fastFlags) Get(key string) (*flagHolder, bool) {
-	if f, ok := ff.flags.Load().(flagMap)[key]; ok && f != nil {
+	if f, ok := ff.load()[key]; ok && f != nil {
 		return f, ok
 	} else {
 		return nil, false
@@ -65,7 +69,7 @@ func (ff *fastFlags) Update(refreshedFlags []*flags2.Flag2) {
 	// this is largely for tests in gocode which compare if flags
 	// are deeply equal in tests.
 	if changed {
-		ff.flags.Store(newFlags)
+		ff.flags.Store(&newFlags)
 	}
 
 	return
@@ -83,7 +87,7 @@ func (ff *fastFlags) storeForTesting(key string, value *flagHolder) {
 
 	newFlags[key] = value
 
-	ff.flags.Store(newFlags)
+	ff.flags.Store(&newFlags)
 }
 
 func (ff *fastFlags) deleteForTesting(keyToDelete string) {
@@ -98,7 +102,7 @@ func (ff *fastFlags) deleteForTesting(keyToDelete string) {
 		}
 	}
 
-	ff.flags.Store(newFlags)
+	ff.flags.Store(&newFlags)
 }
 
 func (ff *fastFlags) Close() {

--- a/fasttags.go
+++ b/fasttags.go
@@ -8,20 +8,24 @@ import (
 // fastTags is a structure for fast access to read-mostly default tags.
 // It supports lockless reads and synchronized updates.
 type fastTags struct {
-	tags atomic.Value
+	tags atomic.Pointer[map[string]string]
 
 	writerLock sync.Mutex
 }
 
 func newFastTags() *fastTags {
 	ft := new(fastTags)
-	ft.tags.Store(make(map[string]string))
+	empty := make(map[string]string)
+	ft.tags.Store(&empty)
 	return ft
 }
 
 // Load returns a map of default tags.  This map MUST only be read, not written to.
 func (ft *fastTags) Load() map[string]string {
-	return ft.tags.Load().(map[string]string)
+	if tags := ft.tags.Load(); tags != nil {
+		return *tags
+	}
+	return nil
 }
 
 // Set replaces the default tags.
@@ -29,12 +33,12 @@ func (ft *fastTags) Set(tags map[string]string) {
 	ft.writerLock.Lock()
 	defer ft.writerLock.Unlock()
 
-	// copy argument into a new map to ensure caller can't easily mistakenly
+	// copy argument into a new map to ensure caller can't mistakenly
 	// hold on to a reference and cause a concurrent map modification panic
-	newTags := make(map[string]string)
+	newTags := make(map[string]string, len(tags))
 	for k, v := range tags {
 		newTags[k] = v
 	}
 
-	ft.tags.Store(newTags)
+	ft.tags.Store(&newTags)
 }

--- a/fasttags.go
+++ b/fasttags.go
@@ -14,10 +14,7 @@ type fastTags struct {
 }
 
 func newFastTags() *fastTags {
-	ft := new(fastTags)
-	empty := make(map[string]string)
-	ft.tags.Store(&empty)
-	return ft
+	return new(fastTags)
 }
 
 // Load returns a map of default tags.  This map MUST only be read, not written to.

--- a/goforit.go
+++ b/goforit.go
@@ -455,8 +455,8 @@ func (g *goforit) Close() error {
 
 	if g.shouldCloseStats {
 		_ = g.getStats().Close()
-		g.stats.Store(nil)
 	}
+	g.stats.Store(nil)
 
 	// clear this so that tests work better
 	g.lastFlagRefreshTime.Store(0)

--- a/goforit.go
+++ b/goforit.go
@@ -125,7 +125,7 @@ func newWithoutInit(stalenessTickerInterval time.Duration) (*goforit, context.Co
 		rnd:                &pooledRandFloater{},
 		ctxOverrideEnabled: true,
 		stalenessTicker:    time.NewTicker(stalenessTickerInterval),
-		printf:             log.New(os.Stderr, "[goforit] ", log.LstdFlags).Printf, //
+		printf:             log.New(os.Stderr, "[goforit] ", log.LstdFlags).Printf,
 		done:               done,
 	}
 
@@ -468,8 +468,6 @@ func (g *goforit) Close() error {
 	// clear this so that tests work better
 	g.lastFlagRefreshTime.Store(0)
 	g.flags.Close()
-
-	g.printf = nil
 
 	return nil
 }

--- a/goforit_test.go
+++ b/goforit_test.go
@@ -812,6 +812,15 @@ func TestGoforit_ReportCounts(t *testing.T) {
 	assert.Greater(t, duration, time.Duration(0))
 }
 
+func TestDefaultFastFlags(t *testing.T) {
+	ff := &fastFlags{}
+
+	// this shouldn't panic/crash on ff.flags being nil
+	h, found := ff.Get("not_in_map")
+	assert.False(t, found)
+	assert.Nil(t, h)
+}
+
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m)
 }

--- a/goforit_test.go
+++ b/goforit_test.go
@@ -135,7 +135,7 @@ var _ io.Writer = &logBuffer{}
 // Also return the log output
 func testGoforit(interval time.Duration, backend Backend, enabledTickerInterval time.Duration, options ...Option) (*goforit, *logBuffer) {
 	g, ctx := newWithoutInit(enabledTickerInterval)
-	g.rnd = newPooledRandomFloater()
+	g.rnd = &pooledRandFloater{}
 	buf := new(logBuffer)
 	g.printf = log.New(buf, "", 9).Printf
 	g.setStats(&mockStatsd{})

--- a/goforit_test.go
+++ b/goforit_test.go
@@ -134,14 +134,14 @@ var _ io.Writer = &logBuffer{}
 // Build a goforit for testing
 // Also return the log output
 func testGoforit(interval time.Duration, backend Backend, enabledTickerInterval time.Duration, options ...Option) (*goforit, *logBuffer) {
-	g := newWithoutInit(enabledTickerInterval)
+	g, ctx := newWithoutInit(enabledTickerInterval)
 	g.rnd = newPooledRandomFloater()
 	buf := new(logBuffer)
 	g.printf = log.New(buf, "", 9).Printf
 	g.setStats(&mockStatsd{})
 
 	if backend != nil {
-		g.init(interval, backend, options...)
+		g.init(interval, backend, ctx, options...)
 	}
 
 	return g, buf

--- a/goforit_test.go
+++ b/goforit_test.go
@@ -625,8 +625,8 @@ func TestRefreshCycleMetric(t *testing.T) {
 	// subtract 2 for iters to avoid flakey tests
 	assert.GreaterOrEqual(t, initialMetricCount, iters-antiFlakeSlack)
 
-	// want to stop ticker to simulate Refresh() hanging
-	g.ticker.Stop()
+	// want to stop refreshTicker to simulate Refresh() hanging
+	g.refreshTicker.Stop()
 	time.Sleep(3 * time.Millisecond)
 
 	for i := 0; i < iters; i++ {
@@ -700,7 +700,7 @@ func TestStaleRefresh(t *testing.T) {
 	g.SetStalenessThreshold(50 * time.Millisecond)
 
 	// Simulate stopping refresh
-	g.ticker.Stop()
+	g.refreshTicker.Stop()
 	time.Sleep(100 * time.Millisecond)
 
 	for i := 0; i < 10; i++ {

--- a/metrics.go
+++ b/metrics.go
@@ -1,0 +1,25 @@
+package goforit
+
+type noopMetricsClient struct{}
+
+func (n noopMetricsClient) Histogram(s string, f float64, strings []string, f2 float64) error {
+	return nil
+}
+
+func (n noopMetricsClient) TimeInMilliseconds(name string, milli float64, tags []string, rate float64) error {
+	return nil
+}
+
+func (n noopMetricsClient) Gauge(s string, f float64, strings []string, f2 float64) error {
+	return nil
+}
+
+func (n noopMetricsClient) Count(s string, i int64, strings []string, f float64) error {
+	return nil
+}
+
+func (n noopMetricsClient) Close() error {
+	return nil
+}
+
+var _ MetricsClient = noopMetricsClient{}


### PR DESCRIPTION
we have internal tests that use other in-memory feature flag implementations in tests that call `reflect.DeepEqual`.  If its not too much contortion, its useful to have `goforit` usable in those same contexts (e.g. ensuring performance running in CI/locally matches built binaries).  I think this PR does that!  the big things are zeroing fields on Close, closing timers, etc, and using `atomic.Pointer[T]` to do that safely.